### PR TITLE
fix: simplify ImageUpdateAutomation messageTemplate

### DIFF
--- a/clusters/eldertree/swimto/image-update-automation.yaml
+++ b/clusters/eldertree/swimto/image-update-automation.yaml
@@ -21,8 +21,6 @@ spec:
       messageTemplate: |
         chore: update swimto images
 
-        {{range .Changed.Images}}{{println .}}{{end}}
-
         Automated image update by Flux
     push:
       branch: main


### PR DESCRIPTION
Simplify the commit message template to avoid template parsing errors with v1 API