### PR TITLE
chore: update swimto images to v2.0.0

### DIFF
--- a/clusters/eldertree/swimto/api-deployment.yaml
+++ b/clusters/eldertree/swimto/api-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: api
-          image: ghcr.io/raolivei/swimto-api:latest # {"$imagepolicy": "swimto:swimto-api-policy"}
+          image: ghcr.io/raolivei/swimto-api:v2.0.0 # {"$imagepolicy": "swimto:swimto-api-policy"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/clusters/eldertree/swimto/web-deployment.yaml
+++ b/clusters/eldertree/swimto/web-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: web
-          image: ghcr.io/raolivei/swimto-web:latest # {"$imagepolicy": "swimto:swimto-web-policy"}
+          image: ghcr.io/raolivei/swimto-web:v2.0.0 # {"$imagepolicy": "swimto:swimto-web-policy"}
           imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Summary
Automated image update by Flux Image Automation

- Update swimto-api to v2.0.0
- Update swimto-web to v2.0.0

🤖 Automated by [Flux](https://fluxcd.io)