### PR TITLE
Add NVMe HAT migration scripts

### DIFF
--- a/scripts/storage/erase-old-drive-safe.sh
+++ b/scripts/storage/erase-old-drive-safe.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Safe erase of old NVMe drive - checks boot source first
+# Usage: ./erase-old-drive-safe.sh [device]
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+DEVICE="${1:-/dev/nvme0n1}"
+
+echo -e "${BLUE}=== Safe Erase Old NVMe Drive ===${NC}"
+echo ""
+
+# Check current boot device
+CURRENT_ROOT=$(df -h / | tail -1 | awk '{print $1}')
+echo -e "${BLUE}Current root: $CURRENT_ROOT${NC}"
+
+# Check if we're trying to erase the boot device
+if [[ "$CURRENT_ROOT" == *"$(basename $DEVICE)"* ]]; then
+    echo -e "${RED}❌ ERROR: Cannot erase the drive you're booting from!${NC}"
+    echo ""
+    echo "Current situation:"
+    echo "  Booting from: $CURRENT_ROOT"
+    echo "  Trying to erase: $DEVICE"
+    echo ""
+    echo -e "${YELLOW}To erase the old drive:${NC}"
+    echo "  1. Boot from SD card (not NVMe)"
+    echo "  2. Then run this script again"
+    echo ""
+    echo "To boot from SD card:"
+    echo "  Option A: Remove NVMe temporarily and boot"
+    echo "  Option B: Update boot config to use SD card, then reboot"
+    echo ""
+    echo "After booting from SD card, verify:"
+    echo "  df -h /  # Should show /dev/mmcblk0p2"
+    echo "  Then run: sudo ./secure-erase-old-nvme.sh $DEVICE"
+    exit 1
+fi
+
+# Check device size to verify it's the old drive
+if [ -b "$DEVICE" ]; then
+    DEVICE_SIZE=$(blockdev --getsize64 "$DEVICE")
+    DEVICE_SIZE_GB=$((DEVICE_SIZE / 1024 / 1024 / 1024))
+    echo -e "${BLUE}Device size: ${DEVICE_SIZE_GB}GB${NC}"
+    
+    if [ "$DEVICE_SIZE_GB" -ge 200 ] && [ "$DEVICE_SIZE_GB" -le 300 ]; then
+        echo -e "${GREEN}✓ This appears to be the old ~256GB drive${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Warning: Size doesn't match expected ~256GB${NC}"
+    fi
+else
+    echo -e "${RED}❌ Device not found: $DEVICE${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}✓ Safe to erase - not booting from this device${NC}"
+echo "  Booting from: $CURRENT_ROOT"
+echo "  Will erase: $DEVICE"
+echo ""
+
+# Run the secure erase script
+if [ -f ./secure-erase-old-nvme.sh ]; then
+    sudo ./secure-erase-old-nvme.sh "$DEVICE"
+elif [ -f ~/secure-erase-old-nvme.sh ]; then
+    sudo ~/secure-erase-old-nvme.sh "$DEVICE"
+else
+    echo -e "${RED}❌ secure-erase-old-nvme.sh not found${NC}"
+    echo "  Please ensure the script is in current directory or home directory"
+    exit 1
+fi
+

--- a/scripts/storage/migrate-nvme-hat.sh
+++ b/scripts/storage/migrate-nvme-hat.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+# Migrate from old NVMe HAT to new M.2 NVMe M-key & PoE+ HAT
+# Preserves boot partition, OS, and K3s cluster data
+# Usage: ./migrate-nvme-hat.sh <node-name>
+# Example: ./migrate-nvme-hat.sh node-1
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+NODE_NAME="${1:-}"
+if [ -z "$NODE_NAME" ]; then
+    echo -e "${RED}❌ Error: Node name required${NC}"
+    echo "Usage: $0 <node-name>"
+    echo "Example: $0 node-1"
+    exit 1
+fi
+
+echo -e "${BLUE}=== NVMe HAT Migration for $NODE_NAME ===${NC}"
+echo ""
+
+# Detect if running on control plane or worker
+if systemctl is-active --quiet k3s 2>/dev/null; then
+    NODE_ROLE="control-plane"
+    K3S_SERVICE="k3s"
+elif systemctl is-active --quiet k3s-agent 2>/dev/null; then
+    NODE_ROLE="worker"
+    K3S_SERVICE="k3s-agent"
+else
+    NODE_ROLE="unknown"
+    K3S_SERVICE=""
+fi
+
+echo -e "${BLUE}Node Role: $NODE_ROLE${NC}"
+echo ""
+
+# Device paths
+SD_CARD="/dev/mmcblk0"
+NVME_DEVICE="/dev/nvme0n1"
+BOOT_PARTITION="${SD_CARD}p1"
+ROOT_PARTITION="${SD_CARD}p2"
+NVME_BOOT="${NVME_DEVICE}p1"
+NVME_ROOT="${NVME_DEVICE}p2"
+
+# Check if devices exist
+if [ ! -b "$SD_CARD" ]; then
+    echo -e "${RED}❌ SD card not found at $SD_CARD${NC}"
+    exit 1
+fi
+
+if [ ! -b "$NVME_DEVICE" ]; then
+    echo -e "${RED}❌ NVMe device not found at $NVME_DEVICE${NC}"
+    echo "  Please ensure new HAT and NVMe are installed"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Devices found${NC}"
+echo "  SD Card: $SD_CARD"
+echo "  NVMe: $NVME_DEVICE"
+echo ""
+
+# Check new NVMe size (should be ~128GB)
+NVME_SIZE=$(blockdev --getsize64 "$NVME_DEVICE")
+NVME_SIZE_GB=$((NVME_SIZE / 1024 / 1024 / 1024))
+echo -e "${BLUE}New NVMe size: ${NVME_SIZE_GB}GB${NC}"
+
+if [ "$NVME_SIZE_GB" -lt 100 ] || [ "$NVME_SIZE_GB" -gt 150 ]; then
+    echo -e "${YELLOW}⚠️  Warning: NVMe size (${NVME_SIZE_GB}GB) doesn't match expected 128GB${NC}"
+    read -p "Continue anyway? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+echo ""
+
+# Determine source for migration
+# After hardware replacement, we'll be booting from SD card, so always use SD as source
+CURRENT_ROOT=$(df -h / | tail -1 | awk '{print $1}')
+echo -e "${BLUE}Current root filesystem: $CURRENT_ROOT${NC}"
+
+# Check if we're currently booting from old NVMe
+if [[ "$CURRENT_ROOT" == *"nvme0n1"* ]]; then
+    echo -e "${YELLOW}⚠️  Currently booting from old NVMe${NC}"
+    echo "  After hardware replacement, you'll boot from SD card"
+    echo "  This script will clone from SD card to new NVMe"
+    echo ""
+    
+    # Check if SD card has bootable partitions
+    if [ ! -b "$BOOT_PARTITION" ] || [ ! -b "$ROOT_PARTITION" ]; then
+        echo -e "${RED}❌ SD card partitions not found${NC}"
+        echo "  Boot: $BOOT_PARTITION"
+        echo "  Root: $ROOT_PARTITION"
+        echo "  Please ensure SD card has bootable OS before hardware replacement"
+        exit 1
+    fi
+    
+    # Verify SD card has OS
+    if ! mountpoint -q /boot/firmware 2>/dev/null; then
+        # Try to mount SD boot to check
+        TEMP_MOUNT="/tmp/sd-boot-check-$$"
+        sudo mkdir -p "$TEMP_MOUNT"
+        if sudo mount "$BOOT_PARTITION" "$TEMP_MOUNT" 2>/dev/null; then
+            if [ -f "$TEMP_MOUNT/cmdline.txt" ]; then
+                echo -e "${GREEN}✓ SD card has bootable OS${NC}"
+            else
+                echo -e "${YELLOW}⚠️  SD card boot partition may not be bootable${NC}"
+            fi
+            sudo umount "$TEMP_MOUNT"
+            rmdir "$TEMP_MOUNT"
+        fi
+    fi
+fi
+
+# After hardware replacement, we'll always use SD card as source
+SOURCE_TYPE="SD"
+SOURCE_BOOT="$BOOT_PARTITION"
+SOURCE_ROOT="$ROOT_PARTITION"
+
+echo -e "${BLUE}Migration source: $SOURCE_TYPE${NC}"
+echo "  Boot: $SOURCE_BOOT"
+echo "  Root: $SOURCE_ROOT"
+echo ""
+
+# Check if K3s is running
+if [ -n "$K3S_SERVICE" ] && systemctl is-active --quiet "$K3S_SERVICE" 2>/dev/null; then
+    echo -e "${YELLOW}⚠️  K3s ($K3S_SERVICE) is running. We'll stop it during migration.${NC}"
+    K3S_RUNNING=true
+else
+    K3S_RUNNING=false
+fi
+echo ""
+
+# Check if new NVMe already has partitions
+if [ -b "$NVME_BOOT" ] || [ -b "$NVME_ROOT" ]; then
+    echo -e "${YELLOW}⚠️  New NVMe already has partitions${NC}"
+    lsblk "$NVME_DEVICE"
+    echo ""
+    read -p "This will erase all data on new NVMe. Continue? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Stop K3s if running
+if [ "$K3S_RUNNING" = true ]; then
+    echo -e "${YELLOW}[1/8] Stopping K3s...${NC}"
+    sudo systemctl stop "$K3S_SERVICE"
+    sleep 2
+    echo -e "${GREEN}✓ K3s stopped${NC}"
+    echo ""
+fi
+
+# Unmount new NVMe if mounted
+echo -e "${YELLOW}[2/8] Unmounting new NVMe if mounted...${NC}"
+for mount in $(mount | grep "$NVME_DEVICE" | awk '{print $3}'); do
+    sudo umount "$mount" 2>/dev/null || true
+done
+echo -e "${GREEN}✓ NVMe unmounted${NC}"
+echo ""
+
+# Create partition table on new NVMe
+echo -e "${YELLOW}[3/8] Creating partitions on new NVMe...${NC}"
+echo "  Creating GPT partition table..."
+sudo parted -s "$NVME_DEVICE" mklabel gpt
+
+# Calculate partition sizes (boot = 1GB to be safe, rest for root)
+# Check actual boot partition size first
+if [ -b "$SOURCE_BOOT" ]; then
+    SOURCE_BOOT_SIZE=$(sudo blockdev --getsize64 "$SOURCE_BOOT" 2>/dev/null || echo "536870912")
+    SOURCE_BOOT_SIZE_MB=$((SOURCE_BOOT_SIZE / 1024 / 1024))
+    # Use source size + 10% buffer, minimum 512MB, maximum 2GB
+    BOOT_SIZE_MB=$((SOURCE_BOOT_SIZE_MB + SOURCE_BOOT_SIZE_MB / 10))
+    if [ "$BOOT_SIZE_MB" -lt 512 ]; then
+        BOOT_SIZE_MB=512
+    elif [ "$BOOT_SIZE_MB" -gt 2048 ]; then
+        BOOT_SIZE_MB=2048
+    fi
+else
+    BOOT_SIZE_MB=1024  # Default 1GB
+fi
+ROOT_START_MB=$((BOOT_SIZE_MB + 1))
+
+echo "  Creating boot partition (${BOOT_SIZE_MB}MB)..."
+sudo parted -s "$NVME_DEVICE" mkpart primary fat32 1MiB ${BOOT_SIZE_MB}MiB
+sudo parted -s "$NVME_DEVICE" set 1 esp on  # Set EFI System Partition flag
+
+echo "  Creating root partition (remaining space)..."
+sudo parted -s "$NVME_DEVICE" mkpart primary ext4 ${ROOT_START_MB}MiB 100%
+
+# Wait for partitions to be available
+sleep 2
+sudo partprobe "$NVME_DEVICE"
+sleep 2
+
+# Format partitions
+echo "  Formatting boot partition..."
+sudo mkfs.vfat -F 32 -n BOOT "${NVME_DEVICE}p1"
+
+echo "  Formatting root partition..."
+sudo mkfs.ext4 -F -L rootfs "${NVME_DEVICE}p2"
+
+echo -e "${GREEN}✓ Partitions created and formatted${NC}"
+echo ""
+
+# Clone boot partition
+echo -e "${YELLOW}[4/8] Cloning boot partition...${NC}"
+echo "  Source: $SOURCE_BOOT"
+echo "  Target: $NVME_BOOT"
+echo "  This may take a few minutes..."
+sudo dd if="$SOURCE_BOOT" of="$NVME_BOOT" bs=4M status=progress conv=fsync
+sudo sync
+echo -e "${GREEN}✓ Boot partition cloned${NC}"
+echo ""
+
+# Mount new boot partition to update cmdline.txt
+echo -e "${YELLOW}[5/8] Updating boot configuration...${NC}"
+sudo mkdir -p /mnt/new-boot
+sudo mount "$NVME_BOOT" /mnt/new-boot
+
+# Update cmdline.txt
+if [ -f /mnt/new-boot/cmdline.txt ]; then
+    sudo cp /mnt/new-boot/cmdline.txt /mnt/new-boot/cmdline.txt.bak.$(date +%Y%m%d-%H%M%S)
+    sudo sed -i.bak "s|root=[^ ]*|root=$NVME_ROOT|g" /mnt/new-boot/cmdline.txt
+    echo -e "${GREEN}✓ cmdline.txt updated${NC}"
+    echo "  Content:"
+    cat /mnt/new-boot/cmdline.txt | sed 's/^/    /'
+else
+    echo -e "${YELLOW}⚠️  cmdline.txt not found, creating default...${NC}"
+    echo "console=serial0,115200 console=tty1 root=$NVME_ROOT rootfstype=ext4 fsck.repair=yes rootwait quiet init=/usr/lib/raspberrypi-sys-mods/first-boot" | sudo tee /mnt/new-boot/cmdline.txt
+fi
+
+sudo umount /mnt/new-boot
+rmdir /mnt/new-boot
+echo ""
+
+# Clone root filesystem
+echo -e "${YELLOW}[6/8] Cloning root filesystem...${NC}"
+echo "  Source: $SOURCE_ROOT"
+echo "  Target: $NVME_ROOT"
+echo "  This is the longest step (10-30 minutes)..."
+echo "  Preserving K3s data and all configurations..."
+
+# Use rsync for better data preservation
+sudo mkdir -p /mnt/source-root /mnt/new-root
+sudo mount "$SOURCE_ROOT" /mnt/source-root
+sudo mount "$NVME_ROOT" /mnt/new-root
+
+# Clone with rsync, excluding some directories
+sudo rsync -aAXHv --info=progress2 \
+    --exclude={"/dev/*","/proc/*","/sys/*","/tmp/*","/run/*","/mnt/*","/media/*","/lost+found"} \
+    /mnt/source-root/ /mnt/new-root/
+
+# Update fstab on new root
+echo -e "${YELLOW}[7/8] Updating fstab...${NC}"
+if [ -f /mnt/new-root/etc/fstab ]; then
+    sudo cp /mnt/new-root/etc/fstab /mnt/new-root/etc/fstab.bak.$(date +%Y%m%d-%H%M%S)
+    sudo sed -i.bak "s|/dev/mmcblk0p1|$NVME_BOOT|g" /mnt/new-root/etc/fstab
+    sudo sed -i.bak "s|/dev/mmcblk0p2|$NVME_ROOT|g" /mnt/new-root/etc/fstab
+    # Update any old NVMe references
+    sudo sed -i.bak "s|/dev/nvme0n1p1|$NVME_BOOT|g" /mnt/new-root/etc/fstab
+    sudo sed -i.bak "s|/dev/nvme0n1p2|$NVME_ROOT|g" /mnt/new-root/etc/fstab
+    echo -e "${GREEN}✓ fstab updated${NC}"
+    echo "  Content:"
+    cat /mnt/new-root/etc/fstab | sed 's/^/    /'
+fi
+
+# Verify K3s data preservation
+if [ -d /mnt/new-root/var/lib/rancher/k3s ]; then
+    echo -e "${GREEN}✓ K3s data preserved${NC}"
+    echo "  Location: /mnt/new-root/var/lib/rancher/k3s"
+    ls -la /mnt/new-root/var/lib/rancher/k3s | head -5 | sed 's/^/    /'
+fi
+
+sudo umount /mnt/new-root
+sudo umount /mnt/source-root
+rmdir /mnt/new-root /mnt/source-root
+echo ""
+
+# Final sync
+echo -e "${YELLOW}[8/8] Finalizing...${NC}"
+sudo sync
+echo -e "${GREEN}✓ Migration complete${NC}"
+echo ""
+
+# Restart K3s if it was running
+if [ "$K3S_RUNNING" = true ]; then
+    echo -e "${YELLOW}Restarting K3s...${NC}"
+    sudo systemctl start "$K3S_SERVICE"
+    sleep 5
+    if systemctl is-active --quiet "$K3S_SERVICE" 2>/dev/null; then
+        echo -e "${GREEN}✓ K3s restarted${NC}"
+    else
+        echo -e "${YELLOW}⚠️  K3s may need manual restart after reboot${NC}"
+    fi
+fi
+
+echo ""
+echo -e "${GREEN}=== Migration Complete ===${NC}"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Reboot: sudo reboot"
+echo "  2. System should boot from new NVMe"
+echo "  3. Verify: df -h / (should show $NVME_ROOT)"
+echo "  4. Check K3s: sudo systemctl status $K3S_SERVICE"
+echo ""
+echo -e "${BLUE}Note:${NC} SD card remains as backup boot option"
+echo ""
+echo -e "${BLUE}Secure Erase Old Drive:${NC}"
+echo "  After verifying migration, you can securely erase the old 256GB drive:"
+echo "  sudo ./secure-erase-old-nvme.sh /dev/nvme0n1"
+echo "  (Replace device path if old drive is on different device)"
+echo ""
+

--- a/scripts/storage/pre-migration-backup.sh
+++ b/scripts/storage/pre-migration-backup.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Pre-migration backup - Run BEFORE hardware replacement
+# Backs up K3s data and critical configs from old NVMe to SD card
+# Usage: ./pre-migration-backup.sh <node-name>
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+NODE_NAME="${1:-}"
+if [ -z "$NODE_NAME" ]; then
+    echo -e "${RED}❌ Error: Node name required${NC}"
+    echo "Usage: $0 <node-name>"
+    echo "Example: $0 node-1"
+    exit 1
+fi
+
+echo -e "${BLUE}=== Pre-Migration Backup for $NODE_NAME ===${NC}"
+echo ""
+
+# Check current boot device
+CURRENT_ROOT=$(df -h / | tail -1 | awk '{print $1}')
+echo -e "${BLUE}Current root: $CURRENT_ROOT${NC}"
+
+if [[ "$CURRENT_ROOT" != *"nvme0n1"* ]]; then
+    echo -e "${YELLOW}⚠️  Not currently booting from NVMe${NC}"
+    echo "  This script is for backing up data before replacing NVMe hardware"
+    read -p "Continue anyway? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Backup directory on SD card
+BACKUP_DIR="/mnt/sd-backup"
+SD_ROOT="/dev/mmcblk0p2"
+
+# Check SD card
+if [ ! -b "$SD_ROOT" ]; then
+    echo -e "${RED}❌ SD card root partition not found at $SD_ROOT${NC}"
+    exit 1
+fi
+
+# Mount SD card root
+echo -e "${YELLOW}[1/4] Mounting SD card...${NC}"
+sudo mkdir -p "$BACKUP_DIR"
+if ! mountpoint -q "$BACKUP_DIR" 2>/dev/null; then
+    sudo mount "$SD_ROOT" "$BACKUP_DIR"
+    MOUNTED=true
+else
+    MOUNTED=false
+fi
+
+# Create backup directory
+BACKUP_PATH="$BACKUP_DIR/nvme-migration-backup-$(date +%Y%m%d-%H%M%S)"
+sudo mkdir -p "$BACKUP_PATH"
+echo -e "${GREEN}✓ SD card mounted${NC}"
+echo "  Backup location: $BACKUP_PATH"
+echo ""
+
+# Backup K3s data
+echo -e "${YELLOW}[2/4] Backing up K3s data...${NC}"
+if [ -d /var/lib/rancher/k3s ]; then
+    K3S_SIZE=$(du -sh /var/lib/rancher/k3s 2>/dev/null | awk '{print $1}' || echo "unknown")
+    echo "  K3s data size: $K3S_SIZE"
+    echo "  Copying to backup..."
+    
+    sudo mkdir -p "$BACKUP_PATH/k3s"
+    sudo rsync -aAXHv --info=progress2 \
+        --exclude={"/dev/*","/proc/*","/sys/*","/tmp/*","/run/*"} \
+        /var/lib/rancher/k3s/ "$BACKUP_PATH/k3s/"
+    
+    echo -e "${GREEN}✓ K3s data backed up${NC}"
+else
+    echo -e "${YELLOW}⚠️  K3s data directory not found${NC}"
+fi
+echo ""
+
+# Backup critical configs
+echo -e "${YELLOW}[3/4] Backing up critical configurations...${NC}"
+sudo mkdir -p "$BACKUP_PATH/configs"
+
+# Backup fstab
+if [ -f /etc/fstab ]; then
+    sudo cp /etc/fstab "$BACKUP_PATH/configs/fstab"
+    echo "  ✓ fstab"
+fi
+
+# Backup network configs
+if [ -d /etc/netplan ]; then
+    sudo cp -r /etc/netplan "$BACKUP_PATH/configs/" 2>/dev/null || true
+    echo "  ✓ netplan"
+fi
+
+# Backup SSH keys
+if [ -d /etc/ssh ]; then
+    sudo cp -r /etc/ssh "$BACKUP_PATH/configs/" 2>/dev/null || true
+    echo "  ✓ SSH config"
+fi
+
+# Backup hostname
+if [ -f /etc/hostname ]; then
+    sudo cp /etc/hostname "$BACKUP_PATH/configs/"
+    echo "  ✓ hostname"
+fi
+
+echo -e "${GREEN}✓ Configurations backed up${NC}"
+echo ""
+
+# Create backup manifest
+echo -e "${YELLOW}[4/4] Creating backup manifest...${NC}"
+MANIFEST_FILE="$BACKUP_PATH/backup-manifest.txt"
+{
+    echo "Backup created: $(date)"
+    echo "Node: $NODE_NAME"
+    echo "Source root: $CURRENT_ROOT"
+    echo ""
+    echo "K3s data:"
+    if [ -d "$BACKUP_PATH/k3s" ]; then
+        du -sh "$BACKUP_PATH/k3s" | awk '{print "  " $0}'
+    else
+        echo "  (not found)"
+    fi
+    echo ""
+    echo "Configurations:"
+    ls -lh "$BACKUP_PATH/configs/" 2>/dev/null | tail -n +2 | awk '{print "  " $0}' || echo "  (none)"
+} | sudo tee "$MANIFEST_FILE" > /dev/null
+
+echo -e "${GREEN}✓ Backup manifest created${NC}"
+echo ""
+
+# Unmount if we mounted it
+if [ "$MOUNTED" = true ]; then
+    sudo umount "$BACKUP_DIR"
+fi
+
+echo -e "${GREEN}=== Backup Complete ===${NC}"
+echo ""
+echo -e "${YELLOW}Backup location: $BACKUP_PATH${NC}"
+echo ""
+echo -e "${BLUE}Next steps:${NC}"
+echo "  1. Power down this node: sudo poweroff"
+echo "  2. Replace HAT and NVMe hardware"
+echo "  3. Boot from SD card"
+echo "  4. Run migration script: ./migrate-nvme-hat.sh $NODE_NAME"
+echo ""
+

--- a/scripts/storage/restore-k3s-from-backup.sh
+++ b/scripts/storage/restore-k3s-from-backup.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Restore K3s cluster data from SD card backup
+# Usage: ./restore-k3s-from-backup.sh <node-name>
+# Example: ./restore-k3s-from-backup.sh node-0
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+NODE_NAME="${1:-}"
+if [ -z "$NODE_NAME" ]; then
+    echo -e "${RED}❌ Error: Node name required${NC}"
+    echo "Usage: $0 <node-name>"
+    echo "Example: $0 node-0"
+    exit 1
+fi
+
+echo -e "${BLUE}=== Restore K3s from Backup for $NODE_NAME ===${NC}"
+echo ""
+
+# Detect node role
+if [ "$NODE_NAME" = "node-0" ]; then
+    NODE_ROLE="control-plane"
+    K3S_SERVICE="k3s"
+elif [ "$NODE_NAME" = "node-1" ]; then
+    NODE_ROLE="worker"
+    K3S_SERVICE="k3s-agent"
+else
+    echo -e "${YELLOW}⚠️  Unknown node name, assuming control-plane${NC}"
+    NODE_ROLE="control-plane"
+    K3S_SERVICE="k3s"
+fi
+
+echo -e "${BLUE}Node Role: $NODE_ROLE${NC}"
+echo ""
+
+# SD card root partition
+SD_ROOT="/dev/mmcblk0p2"
+MOUNT_POINT="/mnt/sd-restore"
+
+# Check SD card exists
+if [ ! -b "$SD_ROOT" ]; then
+    echo -e "${RED}❌ SD card not found at $SD_ROOT${NC}"
+    exit 1
+fi
+
+# Mount SD card
+echo -e "${YELLOW}[1/5] Mounting SD card...${NC}"
+sudo mkdir -p "$MOUNT_POINT"
+if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+    sudo mount "$SD_ROOT" "$MOUNT_POINT"
+    MOUNTED=true
+else
+    MOUNTED=false
+fi
+echo -e "${GREEN}✓ SD card mounted${NC}"
+echo ""
+
+# Find backup directory
+echo -e "${YELLOW}[2/5] Finding backup...${NC}"
+BACKUP_DIR=""
+
+# Look for migration backup
+if [ -d "$MOUNT_POINT/nvme-migration-backup-"* ]; then
+    BACKUP_DIR=$(ls -td "$MOUNT_POINT/nvme-migration-backup-"* 2>/dev/null | head -1)
+    echo "  Found migration backup: $BACKUP_DIR"
+    if [ -d "$BACKUP_DIR/k3s" ]; then
+        echo -e "${GREEN}✓ K3s backup found${NC}"
+    fi
+# Check for direct K3s data on SD card
+elif [ -d "$MOUNT_POINT/var/lib/rancher/k3s" ]; then
+    BACKUP_DIR="$MOUNT_POINT"
+    echo "  Found K3s data directly on SD card: $BACKUP_DIR/var/lib/rancher/k3s"
+    echo -e "${GREEN}✓ K3s data found${NC}"
+else
+    echo -e "${RED}❌ No K3s backup found on SD card${NC}"
+    if [ "$MOUNTED" = true ]; then
+        sudo umount "$MOUNT_POINT"
+    fi
+    exit 1
+fi
+
+# Determine K3s source path
+if [ -d "$BACKUP_DIR/k3s" ]; then
+    K3S_SOURCE="$BACKUP_DIR/k3s"
+elif [ -d "$BACKUP_DIR/var/lib/rancher/k3s" ]; then
+    K3S_SOURCE="$BACKUP_DIR/var/lib/rancher/k3s"
+else
+    echo -e "${RED}❌ K3s data not found in backup${NC}"
+    if [ "$MOUNTED" = true ]; then
+        sudo umount "$MOUNT_POINT"
+    fi
+    exit 1
+fi
+
+K3S_SIZE=$(sudo du -sh "$K3S_SOURCE" 2>/dev/null | awk '{print $1}' || echo "unknown")
+echo "  K3s data size: $K3S_SIZE"
+echo ""
+
+# Check if K3s is installed
+echo -e "${YELLOW}[3/5] Checking K3s installation...${NC}"
+if command -v k3s &> /dev/null || [ -f /usr/local/bin/k3s ]; then
+    echo -e "${GREEN}✓ K3s is installed${NC}"
+    K3S_INSTALLED=true
+else
+    echo -e "${YELLOW}⚠️  K3s not installed, will install first${NC}"
+    K3S_INSTALLED=false
+fi
+
+# Stop K3s if running
+if systemctl is-active --quiet "$K3S_SERVICE" 2>/dev/null; then
+    echo -e "${YELLOW}[4/5] Stopping K3s service...${NC}"
+    sudo systemctl stop "$K3S_SERVICE"
+    echo -e "${GREEN}✓ K3s service stopped${NC}"
+else
+    echo -e "${YELLOW}[4/5] K3s service not running${NC}"
+fi
+echo ""
+
+# Restore K3s data
+echo -e "${YELLOW}[5/5] Restoring K3s data...${NC}"
+K3S_TARGET="/var/lib/rancher/k3s"
+
+# Create target directory
+sudo mkdir -p "$K3S_TARGET"
+
+# Backup existing data if it exists
+if [ -d "$K3S_TARGET" ] && [ "$(ls -A $K3S_TARGET 2>/dev/null)" ]; then
+    BACKUP_EXISTING="$K3S_TARGET.backup-$(date +%Y%m%d-%H%M%S)"
+    echo "  Backing up existing data to: $BACKUP_EXISTING"
+    sudo mv "$K3S_TARGET" "$BACKUP_EXISTING"
+    sudo mkdir -p "$K3S_TARGET"
+fi
+
+# Restore data
+echo "  Copying from: $K3S_SOURCE"
+echo "  Copying to: $K3S_TARGET"
+echo "  This may take a few minutes..."
+
+sudo rsync -aAXHv --info=progress2 \
+    --exclude={"/dev/*","/proc/*","/sys/*","/tmp/*","/run/*"} \
+    "$K3S_SOURCE/" "$K3S_TARGET/"
+
+echo -e "${GREEN}✓ K3s data restored${NC}"
+echo ""
+
+# Set correct permissions
+echo "  Setting permissions..."
+sudo chown -R root:root "$K3S_TARGET"
+sudo chmod -R 755 "$K3S_TARGET"
+echo -e "${GREEN}✓ Permissions set${NC}"
+echo ""
+
+# Unmount SD card
+if [ "$MOUNTED" = true ]; then
+    sudo umount "$MOUNT_POINT"
+    rmdir "$MOUNT_POINT" 2>/dev/null || true
+fi
+
+echo -e "${GREEN}=== Restore Complete ===${NC}"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Start K3s service: sudo systemctl start $K3S_SERVICE"
+echo "  2. Check status: sudo systemctl status $K3S_SERVICE"
+echo "  3. Verify cluster: kubectl get nodes (if on control plane)"
+echo ""
+

--- a/scripts/storage/secure-erase-old-nvme.sh
+++ b/scripts/storage/secure-erase-old-nvme.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Secure erase old NVMe drives before returning them
+# This script securely wipes the old 256GB SSDs
+# Usage: ./secure-erase-old-nvme.sh [device]
+# Example: ./secure-erase-old-nvme.sh /dev/nvme0n1
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+DEVICE="${1:-/dev/nvme0n1}"
+
+echo -e "${BLUE}=== Secure Erase Old NVMe Drive ===${NC}"
+echo ""
+
+# Check if device exists
+if [ ! -b "$DEVICE" ]; then
+    echo -e "${RED}❌ Device not found: $DEVICE${NC}"
+    echo "  Available NVMe devices:"
+    lsblk | grep nvme || echo "    (none found)"
+    exit 1
+fi
+
+# Get device info
+DEVICE_SIZE=$(blockdev --getsize64 "$DEVICE")
+DEVICE_SIZE_GB=$((DEVICE_SIZE / 1024 / 1024 / 1024))
+DEVICE_MODEL=$(nvme id-ctrl "$DEVICE" 2>/dev/null | grep -i "mn " | awk -F: '{print $2}' | xargs || echo "unknown")
+
+echo -e "${BLUE}Device Information:${NC}"
+echo "  Device: $DEVICE"
+echo "  Size: ${DEVICE_SIZE_GB}GB"
+echo "  Model: $DEVICE_MODEL"
+echo ""
+
+# Safety check - verify this is the old drive (should be ~256GB)
+if [ "$DEVICE_SIZE_GB" -lt 200 ] || [ "$DEVICE_SIZE_GB" -gt 300 ]; then
+    echo -e "${YELLOW}⚠️  Warning: Device size (${DEVICE_SIZE_GB}GB) doesn't match expected ~256GB${NC}"
+    echo "  Old drives should be approximately 256GB"
+    read -p "Continue anyway? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Check if device is in use
+echo -e "${YELLOW}Checking if device is in use...${NC}"
+if mount | grep -q "$DEVICE"; then
+    echo -e "${RED}❌ Device is mounted!${NC}"
+    echo "  Mounted locations:"
+    mount | grep "$DEVICE" | awk '{print "    " $3}'
+    echo ""
+    echo "Please unmount all partitions on this device first:"
+    mount | grep "$DEVICE" | awk '{print "  sudo umount " $3}'
+    exit 1
+fi
+
+# Check if any partitions are in use
+for part in $(lsblk -n -o NAME "$DEVICE" | grep -v "^$(basename $DEVICE)$"); do
+    if mount | grep -q "$part"; then
+        echo -e "${RED}❌ Partition $part is mounted!${NC}"
+        mount | grep "$part" | awk '{print "  Mounted at: " $3}'
+        echo "  Please unmount: sudo umount /dev/$part"
+        exit 1
+    fi
+done
+
+echo -e "${GREEN}✓ Device is not in use${NC}"
+echo ""
+
+# Final warning
+echo -e "${RED}⚠️  WARNING: This will PERMANENTLY ERASE all data on $DEVICE${NC}"
+echo "  This action cannot be undone!"
+echo "  All partitions and data will be destroyed"
+echo ""
+read -p "Are you sure you want to securely erase $DEVICE? Type 'ERASE' to confirm: " -r
+echo
+if [[ ! "$REPLY" == "ERASE" ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+# Method 1: Try NVMe format with secure erase
+echo -e "${YELLOW}[1/3] Attempting NVMe secure erase...${NC}"
+if command -v nvme &> /dev/null; then
+    # Check if secure erase is supported
+    if nvme id-ctrl "$DEVICE" 2>/dev/null | grep -q "Format.*Supported"; then
+        echo "  Formatting with secure erase..."
+        # Format with crypto erase (fast) or user data erase (slower but more secure)
+        echo -e "${YELLOW}  Choose erase method:${NC}"
+        echo "  1) Crypto Erase (fast, uses encryption keys)"
+        echo "  2) User Data Erase (slower, overwrites data)"
+        read -p "  Select [1-2]: " -n 1 -r
+        echo
+        
+        if [[ "$REPLY" == "1" ]]; then
+            ERASE_METHOD="crypto"
+        else
+            ERASE_METHOD="user"
+        fi
+        
+        echo "  Executing secure erase (this may take a while)..."
+        if nvme format "$DEVICE" -s "$ERASE_METHOD" -f 2>&1; then
+            echo -e "${GREEN}✓ Secure erase completed${NC}"
+            ERASE_SUCCESS=true
+        else
+            echo -e "${YELLOW}⚠️  NVMe secure erase failed, trying alternative method...${NC}"
+            ERASE_SUCCESS=false
+        fi
+    else
+        echo -e "${YELLOW}⚠️  Secure erase not supported via NVMe command, trying alternative...${NC}"
+        ERASE_SUCCESS=false
+    fi
+else
+    echo -e "${YELLOW}⚠️  nvme-cli not available, trying alternative method...${NC}"
+    ERASE_SUCCESS=false
+fi
+
+# Method 2: If NVMe secure erase failed, use dd to overwrite
+if [ "$ERASE_SUCCESS" != "true" ]; then
+    echo -e "${YELLOW}[2/3] Using dd to overwrite device...${NC}"
+    echo "  This will write zeros to the entire device"
+    echo "  Estimated time: $(($DEVICE_SIZE_GB / 100))-$(($DEVICE_SIZE_GB / 50)) minutes"
+    echo ""
+    read -p "Continue with dd overwrite? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+    
+    echo "  Writing zeros to $DEVICE..."
+    echo "  (This may take a long time - be patient)"
+    sudo dd if=/dev/zero of="$DEVICE" bs=1M status=progress conv=fsync 2>&1 || {
+        echo -e "${YELLOW}⚠️  dd failed, trying shred...${NC}"
+        # Fallback to shred if dd fails
+        if command -v shred &> /dev/null; then
+            sudo shred -v -n 1 -z "$DEVICE"
+        else
+            echo -e "${RED}❌ Both dd and shred failed${NC}"
+            exit 1
+        fi
+    }
+    
+    echo -e "${GREEN}✓ Device overwritten with zeros${NC}"
+fi
+
+# Method 3: Final verification - check that device is empty
+echo -e "${YELLOW}[3/3] Verifying erase...${NC}"
+# Check first few MB to see if they're zeros
+FIRST_MB=$(sudo dd if="$DEVICE" bs=1M count=1 2>/dev/null | od -An -tx1 | head -1)
+if [[ "$FIRST_MB" == *"00 00 00"* ]] || [[ "$FIRST_MB" == "" ]]; then
+    echo -e "${GREEN}✓ Verification: Device appears to be erased${NC}"
+else
+    echo -e "${YELLOW}⚠️  Verification: Device may still contain data${NC}"
+    echo "  First MB content: $FIRST_MB"
+fi
+
+# Show final device status
+echo ""
+echo -e "${GREEN}=== Erase Complete ===${NC}"
+echo ""
+echo -e "${BLUE}Device status:${NC}"
+lsblk "$DEVICE"
+echo ""
+echo -e "${YELLOW}Note:${NC} Device partitions may still be visible but data is erased"
+echo "  You can now safely return this drive"
+echo ""
+

--- a/scripts/storage/switch-boot-to-sd.sh
+++ b/scripts/storage/switch-boot-to-sd.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Switch boot to SD card so we can erase old NVMe
+# This updates boot config to boot from SD card on next reboot
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== Switch Boot to SD Card ===${NC}"
+echo ""
+
+# Check current boot
+CURRENT_ROOT=$(df -h / | tail -1 | awk '{print $1}')
+echo -e "${BLUE}Current root: $CURRENT_ROOT${NC}"
+
+if [[ "$CURRENT_ROOT" == *"mmcblk0"* ]]; then
+    echo -e "${GREEN}✓ Already booting from SD card${NC}"
+    echo "  You can now erase the old NVMe drive"
+    exit 0
+fi
+
+# Check SD card exists
+SD_CARD="/dev/mmcblk0"
+SD_BOOT="/dev/mmcblk0p1"
+SD_ROOT="/dev/mmcblk0p2"
+
+if [ ! -b "$SD_BOOT" ] || [ ! -b "$SD_ROOT" ]; then
+    echo -e "${RED}❌ SD card partitions not found${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ SD card found${NC}"
+echo ""
+
+# Mount SD card boot partition
+TEMP_MOUNT="/tmp/sd-boot-switch-$$"
+sudo mkdir -p "$TEMP_MOUNT"
+
+if ! sudo mount "$SD_BOOT" "$TEMP_MOUNT" 2>/dev/null; then
+    echo -e "${RED}❌ Failed to mount SD card boot partition${NC}"
+    exit 1
+fi
+
+# Update cmdline.txt on SD card to boot from SD
+if [ -f "$TEMP_MOUNT/cmdline.txt" ]; then
+    echo -e "${YELLOW}Updating SD card boot configuration...${NC}"
+    sudo cp "$TEMP_MOUNT/cmdline.txt" "$TEMP_MOUNT/cmdline.txt.bak.$(date +%Y%m%d-%H%M%S)"
+    
+    # Update root to SD card
+    sudo sed -i.bak "s|root=[^ ]*|root=$SD_ROOT|g" "$TEMP_MOUNT/cmdline.txt"
+    
+    echo -e "${GREEN}✓ SD card boot config updated${NC}"
+    echo "  Updated cmdline.txt:"
+    cat "$TEMP_MOUNT/cmdline.txt" | sed 's/^/    /'
+else
+    echo -e "${RED}❌ cmdline.txt not found on SD card boot partition${NC}"
+    sudo umount "$TEMP_MOUNT"
+    rmdir "$TEMP_MOUNT"
+    exit 1
+fi
+
+sudo umount "$TEMP_MOUNT"
+rmdir "$TEMP_MOUNT"
+
+echo ""
+echo -e "${GREEN}=== Boot Configuration Updated ===${NC}"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Reboot: sudo reboot"
+echo "  2. System should boot from SD card"
+echo "  3. Verify: df -h / (should show $SD_ROOT)"
+echo "  4. Then erase old NVMe: sudo ./secure-erase-old-nvme.sh /dev/nvme0n1"
+echo ""
+

--- a/scripts/storage/verify-nvme-migration.sh
+++ b/scripts/storage/verify-nvme-migration.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Verify NVMe migration was successful
+# Usage: ./verify-nvme-migration.sh [node-name]
+# Can be run locally on the node or remotely via SSH
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+NODE_NAME="${1:-$(hostname)}"
+
+echo -e "${BLUE}=== NVMe Migration Verification for $NODE_NAME ===${NC}"
+echo ""
+
+# Check root filesystem
+echo -e "${YELLOW}[1/5] Checking root filesystem...${NC}"
+ROOT_DEVICE=$(df -h / | tail -1 | awk '{print $1}')
+echo "  Root device: $ROOT_DEVICE"
+
+if [[ "$ROOT_DEVICE" == *"nvme0n1p2"* ]]; then
+    echo -e "${GREEN}✓ Booting from new NVMe${NC}"
+    BOOT_FROM_NVME=true
+else
+    echo -e "${YELLOW}⚠️  Not booting from new NVMe (currently: $ROOT_DEVICE)${NC}"
+    BOOT_FROM_NVME=false
+fi
+echo ""
+
+# Check boot partition
+echo -e "${YELLOW}[2/5] Checking boot partition...${NC}"
+BOOT_MOUNT=$(mount | grep "/boot/firmware" | awk '{print $1}' || echo "")
+if [ -n "$BOOT_MOUNT" ]; then
+    echo "  Boot partition: $BOOT_MOUNT"
+    if [[ "$BOOT_MOUNT" == *"nvme0n1p1"* ]]; then
+        echo -e "${GREEN}✓ Boot partition on new NVMe${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Boot partition not on new NVMe${NC}"
+    fi
+else
+    echo -e "${YELLOW}⚠️  Boot partition not mounted${NC}"
+fi
+echo ""
+
+# Check NVMe device
+echo -e "${YELLOW}[3/5] Checking NVMe device...${NC}"
+if [ -b /dev/nvme0n1 ]; then
+    NVME_SIZE=$(blockdev --getsize64 /dev/nvme0n1)
+    NVME_SIZE_GB=$((NVME_SIZE / 1024 / 1024 / 1024))
+    echo "  NVMe device: /dev/nvme0n1"
+    echo "  Size: ${NVME_SIZE_GB}GB"
+    
+    if [ "$NVME_SIZE_GB" -ge 100 ] && [ "$NVME_SIZE_GB" -le 150 ]; then
+        echo -e "${GREEN}✓ NVMe size matches expected 128GB${NC}"
+    else
+        echo -e "${YELLOW}⚠️  NVMe size (${NVME_SIZE_GB}GB) doesn't match expected 128GB${NC}"
+    fi
+    
+    echo ""
+    echo "  Partition layout:"
+    lsblk /dev/nvme0n1 | sed 's/^/    /'
+else
+    echo -e "${RED}❌ NVMe device not found${NC}"
+fi
+echo ""
+
+# Check K3s status
+echo -e "${YELLOW}[4/5] Checking K3s status...${NC}"
+if systemctl is-active --quiet k3s 2>/dev/null; then
+    echo -e "${GREEN}✓ K3s server is running${NC}"
+    K3S_STATUS="server"
+elif systemctl is-active --quiet k3s-agent 2>/dev/null; then
+    echo -e "${GREEN}✓ K3s agent is running${NC}"
+    K3S_STATUS="agent"
+else
+    echo -e "${YELLOW}⚠️  K3s is not running${NC}"
+    K3S_STATUS="none"
+fi
+
+if [ -d /var/lib/rancher/k3s ]; then
+    echo -e "${GREEN}✓ K3s data directory exists${NC}"
+    K3S_DATA_SIZE=$(du -sh /var/lib/rancher/k3s 2>/dev/null | awk '{print $1}' || echo "unknown")
+    echo "  Data size: $K3S_DATA_SIZE"
+else
+    echo -e "${YELLOW}⚠️  K3s data directory not found${NC}"
+fi
+echo ""
+
+# Check boot configuration
+echo -e "${YELLOW}[5/5] Checking boot configuration...${NC}"
+if [ -f /boot/firmware/cmdline.txt ]; then
+    if grep -q "root=/dev/nvme0n1p2" /boot/firmware/cmdline.txt; then
+        echo -e "${GREEN}✓ cmdline.txt configured for new NVMe${NC}"
+    else
+        echo -e "${YELLOW}⚠️  cmdline.txt may not be configured for new NVMe${NC}"
+        echo "  Current root setting:"
+        grep -o "root=[^ ]*" /boot/firmware/cmdline.txt | sed 's/^/    /' || echo "    (not found)"
+    fi
+else
+    echo -e "${YELLOW}⚠️  cmdline.txt not found${NC}"
+fi
+
+if [ -f /etc/fstab ]; then
+    if grep -q "nvme0n1" /etc/fstab; then
+        echo -e "${GREEN}✓ fstab references new NVMe${NC}"
+    else
+        echo -e "${YELLOW}⚠️  fstab may not reference new NVMe${NC}"
+    fi
+fi
+echo ""
+
+# Summary
+echo -e "${BLUE}=== Verification Summary ===${NC}"
+echo ""
+if [ "$BOOT_FROM_NVME" = true ]; then
+    echo -e "${GREEN}✅ Migration appears successful${NC}"
+    echo "  - Booting from new NVMe"
+    echo "  - K3s status: $K3S_STATUS"
+    echo ""
+    echo -e "${YELLOW}Recommendations:${NC}"
+    echo "  1. Verify cluster health: kubectl get nodes"
+    echo "  2. Check all pods: kubectl get pods -A"
+    echo "  3. Test storage performance if needed"
+else
+    echo -e "${YELLOW}⚠️  Migration may not be complete${NC}"
+    echo "  - Not currently booting from new NVMe"
+    echo ""
+    echo -e "${YELLOW}Next steps:${NC}"
+    echo "  1. Reboot the system: sudo reboot"
+    echo "  2. After reboot, run this script again to verify"
+fi
+echo ""
+


### PR DESCRIPTION
Adds automated scripts for migrating Raspberry Pi nodes from SD card to NVMe HAT storage:

- `migrate-nvme-hat.sh`: Automated migration from SD to NVMe
- `verify-nvme-migration.sh`: Verification script for migration
- `pre-migration-backup.sh`: Backup K3s data before migration
- `restore-k3s-from-backup.sh`: Restore K3s cluster from backup
- `secure-erase-old-nvme.sh`: Securely erase old drives
- `erase-old-drive-safe.sh`: Safe drive erasure with checks
- `switch-boot-to-sd.sh`: Switch boot source to SD card