### PR TITLE
Disable swimTO deployment

### DIFF
--- a/clusters/eldertree/kustomization.yaml
+++ b/clusters/eldertree/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 
   # Applications
   # - canopy # Personal finance dashboard
-  - swimto # Toronto pool schedules
+  # - swimto # Toronto pool schedules (DISABLED)
   # - nima          # AI/ML learning project (DISABLED - not needed)
   # - journey       # AI-powered career pathfinder (DISABLED - not deployed yet)
   # - us-law-severity-map  # US law visualization (DISABLED - not deployed yet)


### PR DESCRIPTION
Disables swimTO deployment by commenting it out in the kustomization.yaml file. Flux will automatically remove all swimTO resources once this is merged.