### PR TITLE
fix: Switch Flux to watch main branch

### DIFF
--- a/clusters/eldertree/flux-system/gotk-sync.yaml
+++ b/clusters/eldertree/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: flux-bootstrap
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/raolivei/pi-fleet


### PR DESCRIPTION
## Summary

Switch Flux GitRepository to watch `main` branch instead of `flux-bootstrap`. This aligns with standard Flux patterns where the bootstrap branch is only used during initial installation.

## Changes

- Updated `gotk-sync.yaml` to point to `main` branch
- This will allow Flux to deploy directly from `main` after PR #42 is merged

## Next Steps

After this PR and PR #42 are merged:
1. Verify Flux successfully switches to watching `main`
2. Delete the `flux-bootstrap` branch (no longer needed)
3. All future development will flow: feature branch → `main` → Flux deployment

## Benefits

- ✅ Eliminates need to sync between two branches
- ✅ Reduces merge conflicts
- ✅ Standard Flux pattern
- ✅ Simpler workflow