### PR TITLE
fix(swimto): fix ghcr-secret ExternalSecret template syntax

### DIFF
--- a/clusters/eldertree/swimto/ghcr-secret-external.yaml
+++ b/clusters/eldertree/swimto/ghcr-secret-external.yaml
@@ -21,7 +21,7 @@ spec:
               "ghcr.io": {
                 "username": "raolivei",
                 "password": "{{ .token }}",
-                "auth": "{{ printf \"raolivei:%s\" .token | b64enc }}"
+                "auth": "{{ printf `raolivei:%s` .token | b64enc }}"
               }
             }
           }


### PR DESCRIPTION
Fixes the dockerconfigjson template syntax in the swimto ghcr-secret ExternalSecret.

- Changed printf quotes from escaped double quotes to backticks
- Template now parses correctly and ExternalSecret syncs successfully
- Resolves image pull secret errors for swimto deployments

Fixes: Image pull secret retrieval errors