### PR TITLE
fix: disable unsupported PodMonitor

### DIFF
--- a/clusters/eldertree/observability/kustomization.yaml
+++ b/clusters/eldertree/observability/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - weave-gitops-gitrepository.yaml # GitRepository for Weave GitOps charts (from GitHub)
   - monitoring-stack-helmrelease.yaml # Prometheus + Grafana monitoring stack
   - flux-ui-helmrelease.yaml # Flux UI (Weave GitOps) for managing FluxCD resources
-  - traefik-servicemonitor.yaml # Traefik metrics (requires Prometheus CRDs, enable after monitoring-stack is deployed)
+  # - traefik-servicemonitor.yaml # Traefik metrics (DISABLED - requires Prometheus Operator / PodMonitor CRD)


### PR DESCRIPTION
Disables the Traefik PodMonitor which was causing Flux reconciliation errors because the PodMonitor CRD is not present in the cluster (using community Prometheus chart instead of Operator).