### PR TITLE
fix: disable KEDA for disabled apps

### DIFF
--- a/helm/keda-scaledobjects/values.yaml
+++ b/helm/keda-scaledobjects/values.yaml
@@ -11,7 +11,7 @@ global:
 
 # Canopy namespace
 canopy:
-  enabled: true
+  enabled: false
   api:
     enabled: true
     minReplicas: 0 # Scale to zero in standby
@@ -74,7 +74,7 @@ nima:
 
 # US Law Severity Map namespace
 usLawSeverityMap:
-  enabled: true
+  enabled: false
   web:
     enabled: true
     minReplicas: 1 # Keep 1 for fast response


### PR DESCRIPTION
Disables KEDA ScaledObjects for canopy and usLawSeverityMap in the values.yaml to prevent Helm install failures when those namespaces are not present.