### PR TITLE
Migrate swimto postgres to Longhorn storage

### DIFF
--- a/clusters/eldertree/swimto/kustomization.yaml
+++ b/clusters/eldertree/swimto/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ghcr-secret-external.yaml
   - configmap.yaml
   - postgres-pvc.yaml
+  - postgres-pvc-longhorn.yaml
   - postgres-deployment.yaml
   - redis-deployment.yaml
   - api-deployment.yaml

--- a/clusters/eldertree/swimto/postgres-deployment.yaml
+++ b/clusters/eldertree/swimto/postgres-deployment.yaml
@@ -31,6 +31,8 @@ spec:
             secretKeyRef:
               name: swimto-secrets
               key: POSTGRES_PASSWORD
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         volumeMounts:
         - name: postgres-storage
           mountPath: /var/lib/postgresql/data
@@ -44,7 +46,7 @@ spec:
       volumes:
       - name: postgres-storage
         persistentVolumeClaim:
-          claimName: postgres-pvc
+          claimName: postgres-pvc-longhorn
 ---
 apiVersion: v1
 kind: Service

--- a/clusters/eldertree/swimto/postgres-pvc-longhorn.yaml
+++ b/clusters/eldertree/swimto/postgres-pvc-longhorn.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc-longhorn
+  namespace: swimto
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # Using Longhorn for distributed storage with replication
+  storageClassName: longhorn
+


### PR DESCRIPTION
- Update postgres deployment to use postgres-pvc-longhorn
- Add PGDATA env var for Longhorn compatibility
- Add postgres-pvc-longhorn.yaml for Flux GitOps management
- Keep old postgres-pvc.yaml for reference (can be removed after verification)