### PR TITLE
Fix ExternalDNS RFC2136 host to use ClusterIP instead of service name

### DIFF
--- a/clusters/eldertree/dns-services/external-dns/helmrelease.yaml
+++ b/clusters/eldertree/dns-services/external-dns/helmrelease.yaml
@@ -27,7 +27,13 @@ spec:
     provider: rfc2136
     env:
       - name: EXTERNAL_DNS_RFC2136_HOST
-        value: "pi-hole.pihole.svc.cluster.local"
+        # WORKAROUND: Use ClusterIP directly to avoid circular DNS dependency
+        # ExternalDNS can't resolve pi-hole.pihole.svc.cluster.local because
+        # it depends on DNS working, which creates a circular dependency.
+        # TODO: Once DNS is stable, consider using service name or creating
+        # a separate BIND service with its own ClusterIP for better stability.
+        # Current ClusterIP: 10.43.30.194 (pi-hole service in pihole namespace)
+        value: "10.43.30.194"
       - name: EXTERNAL_DNS_RFC2136_PORT
         value: "5353"
       - name: EXTERNAL_DNS_RFC2136_ZONE


### PR DESCRIPTION
## Problem
ExternalDNS was failing with 'no such host' error when trying to resolve `pi-hole.pihole.svc.cluster.local`. This creates a circular dependency since ExternalDNS needs DNS to work, but DNS depends on ExternalDNS creating records.

## Solution
Use ClusterIP (10.43.30.194) directly to avoid DNS resolution. This is a temporary workaround until DNS is stable.

## Testing
- Port 5353 is accessible from within the cluster
- BIND container is running and ready
- Service endpoints include port 5353

## Next Steps
Once DNS is stable, we can switch back to using the service name for better stability.