### PR TITLE
chore(swimto): add auto-PR workflow for Flux image updates

### DIFF
--- a/.github/workflows/flux-swimto-pr.yml
+++ b/.github/workflows/flux-swimto-pr.yml
@@ -1,0 +1,41 @@
+name: Create PR for swimTO Image Updates
+
+on:
+  push:
+    branches:
+      - flux/swimto-image-updates
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: flux/swimto-image-updates
+          base: main
+          title: "chore(swimto): update container images"
+          body: |
+            Automated PR created by Flux Image Update Automation.
+            
+            This PR updates swimTO container image tags to the latest versions.
+          labels: |
+            swimto
+            auto-pr
+            image-update
+          delete-branch: false
+
+      - name: Enable Auto-Merge
+        if: steps.create-pr.outputs.pull-request-number
+        run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Creates a GitHub Actions workflow that automatically creates a PR when Flux Image Update Automation pushes to the `flux/swimto-image-updates` branch.

## Problem

Currently, Flux Image Update Automation pushes commits to the `flux/swimto-image-updates` branch but does NOT create a PR. This requires manual intervention to merge the changes.

## Solution

This workflow completes the GitOps automation loop:

```
swimTO CI → GHCR → Flux detects → Commits to branch → This workflow creates PR → Auto-merge → Flux syncs to cluster
```

## Features

- Triggers on push to `flux/swimto-image-updates` branch
- Creates PR using `peter-evans/create-pull-request` action
- Enables auto-merge with squash strategy
- Adds labels: `swimto`, `auto-pr`, `image-update`

## Requirements

For auto-merge to work, ensure these settings are enabled:
- **Settings > General > Pull Requests > Allow auto-merge** must be enabled
- Branch protection rules should allow PRs to merge after status checks pass

## Files Added

- `.github/workflows/flux-swimto-pr.yml`