### PR TITLE
fix(ansible): add missing UFW rule for k3s API server port 6443

### DIFF
--- a/ansible/playbooks/convert-worker-to-control-plane.yml
+++ b/ansible/playbooks/convert-worker-to-control-plane.yml
@@ -229,7 +229,7 @@
       when: inventory_hostname != 'node-1' and k3s_ready.rc != 0
 
     # =========================================================================
-    # Firewall Configuration for HA Control Plane (etcd ports)
+    # Firewall Configuration for HA Control Plane (API server + etcd ports)
     # =========================================================================
     - name: Check if UFW is installed
       command: which ufw
@@ -237,6 +237,17 @@
       changed_when: false
       failed_when: false
       when: inventory_hostname != 'node-1'
+
+    - name: Ensure UFW allows k3s API server port (6443)
+      ufw:
+        rule: allow
+        port: "6443"
+        proto: tcp
+        comment: "k3s API server"
+      when:
+        - inventory_hostname != 'node-1'
+        - ufw_installed.rc == 0
+      register: ufw_api_server
 
     - name: Ensure UFW allows etcd client port (2379)
       ufw:

--- a/ansible/playbooks/install-k3s.yml
+++ b/ansible/playbooks/install-k3s.yml
@@ -609,7 +609,7 @@
       when: token_fetch.changed | default(false)
 
     # =========================================================================
-    # Firewall Configuration for HA Control Plane (etcd ports)
+    # Firewall Configuration for HA Control Plane (API server + etcd ports)
     # =========================================================================
     - name: Check if UFW is installed
       command: which ufw
@@ -617,6 +617,17 @@
       changed_when: false
       failed_when: false
       when: k3s_role == 'control-plane'
+
+    - name: Ensure UFW allows k3s API server port (6443)
+      ufw:
+        rule: allow
+        port: "6443"
+        proto: tcp
+        comment: "k3s API server"
+      when:
+        - k3s_role == 'control-plane'
+        - ufw_installed.rc == 0
+      register: ufw_api_server
 
     - name: Ensure UFW allows etcd client port (2379)
       ufw:


### PR DESCRIPTION
## Problem
The k3s API server port (6443) was missing from the firewall rules for control plane nodes. This caused the kube-vip HA VIP to become unreachable when leadership failed over to nodes 2 or 3.

## Root Cause
When nodes were set up at different times, only node-1 had the 6443 UFW rule. kube-vip worked correctly, but when it failed over to node-2 or node-3, the API server was blocked by UFW.

## Changes
- `install-k3s.yml`: Added UFW allow rule for 6443/tcp
- `convert-worker-to-control-plane.yml`: Added UFW allow rule for 6443/tcp
- Removed standalone `fix-k3s-ha-bind-address.yml` (now integrated)

## Testing
- Verified all 3 nodes now respond on port 6443
- Verified VIP (192.168.2.100:6443) is accessible
- kubectl commands work via VIP