### PR TITLE
fix(flux): add required fields to local-path StorageClass patch

### DIFF
--- a/clusters/eldertree/core-infrastructure/storage-class-default-patch.yaml
+++ b/clusters/eldertree/core-infrastructure/storage-class-default-patch.yaml
@@ -1,9 +1,13 @@
 ---
 # Patch to ensure only Longhorn is the default storage class
 # local-path (k3s default) should NOT be the default
+# Note: provisioner is required even for patches to pass validation
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-path
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
## Problem
Flux kustomization was failing with:
```
StorageClass/local-path dry-run failed: provisioner: Required value, updates to provisioner are forbidden
```

This blocked **all** resources from being applied, including swimto deployments.

## Root Cause
The `storage-class-default-patch.yaml` was missing the required `provisioner` field. Kubernetes validates the full object during dry-run.

## Fix
Added required fields to make it a valid StorageClass that can be applied as an update.