### PR TITLE
fix(swimto): add emptyDir volumes for nginx cache

### DIFF
--- a/clusters/eldertree/swimto/web-deployment.yaml
+++ b/clusters/eldertree/swimto/web-deployment.yaml
@@ -43,6 +43,20 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-tmp
+              mountPath: /tmp
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Problem
swimto-web crashing with:
```
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

## Root Cause
Nginx running as non-root (UID 1000) can't write to default cache directories.

## Fix
Added emptyDir volumes for:
- `/var/cache/nginx` - client_temp, proxy_temp, etc.
- `/var/run` - pid file
- `/tmp` - temp files