### PR TITLE
fix: rename flux-ui.eldertree.local to flux.eldertree.local

### DIFF
--- a/SERVICES_REFERENCE.md
+++ b/SERVICES_REFERENCE.md
@@ -119,7 +119,7 @@ dig @192.168.2.201 grafana.eldertree.local
 
 | Property           | Value                                           |
 | ------------------ | ----------------------------------------------- |
-| **Local URL**      | `https://flux-ui.eldertree.local` (if deployed) |
+| **Local URL**      | `https://flux.eldertree.local` (if deployed) |
 | **Namespace**      | `flux-system`                                   |
 | **Git Repository** | `https://github.com/raolivei/pi-fleet`          |
 | **Branch**         | `main`                                          |

--- a/clusters/eldertree/observability/flux-ui-helmrelease.yaml
+++ b/clusters/eldertree/observability/flux-ui-helmrelease.yaml
@@ -40,14 +40,14 @@ spec:
         enabled: true
         ingressClassName: traefik
         hosts:
-          - host: flux-ui.eldertree.local
+          - host: flux.eldertree.local
             paths:
               - path: /
                 pathType: Prefix
         tls:
           - secretName: flux-ui-tls
             hosts:
-              - flux-ui.eldertree.local
+              - flux.eldertree.local
         annotations:
           cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
       

--- a/docs/eldertree-local-hosts-block.txt
+++ b/docs/eldertree-local-hosts-block.txt
@@ -14,7 +14,7 @@ TRAEFIK_LB_IP  swimto.eldertree.local
 TRAEFIK_LB_IP  canopy.eldertree.local
 TRAEFIK_LB_IP  pitanga.eldertree.local
 TRAEFIK_LB_IP  pushgateway.eldertree.local
-TRAEFIK_LB_IP  flux-ui.eldertree.local
+TRAEFIK_LB_IP  flux.eldertree.local
 TRAEFIK_LB_IP  alertmanager.eldertree.local
 TRAEFIK_LB_IP  docs.eldertree.local
 TRAEFIK_LB_IP  journey.eldertree.local

--- a/helm/flux-ui/README.md
+++ b/helm/flux-ui/README.md
@@ -22,7 +22,7 @@ Currently, Weave GitOps is deployed directly via HelmRelease referencing the Hel
 
 The deployment configures Traefik ingress with TLS certificates via cert-manager.
 
-Default host: `flux-ui.eldertree.local`
+Default host: `flux.eldertree.local`
 
 ### Resources
 
@@ -37,7 +37,7 @@ Weave GitOps requires cluster-admin permissions to manage FluxCD resources. The 
 ## Access
 
 After deployment, access the UI at:
-- URL: `https://flux-ui.eldertree.local` (via ingress)
+- URL: `https://flux.eldertree.local` (via ingress)
 - Or port-forward: `kubectl port-forward -n observability svc/weave-gitops 9001:9001`
 
 ## Dependencies

--- a/helm/flux-ui/values.yaml
+++ b/helm/flux-ui/values.yaml
@@ -22,14 +22,14 @@ weave-gitops:
     enabled: true
     ingressClassName: traefik
     hosts:
-      - host: flux-ui.eldertree.local
+      - host: flux.eldertree.local
         paths:
           - path: /
             pathType: Prefix
     tls:
       - secretName: flux-ui-tls
         hosts:
-          - flux-ui.eldertree.local
+          - flux.eldertree.local
     annotations:
       cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
   

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -89,13 +89,13 @@ pitanga.eldertree.local {
 }
 
 # Flux UI (GitOps dashboard)
-flux-ui.eldertree.local {
+flux.eldertree.local {
     tls internal
     reverse_proxy https://192.168.2.101:32474 {
         transport http {
             tls_insecure_skip_verify
         }
-        header_up Host flux-ui.eldertree.local
+        header_up Host flux.eldertree.local
     }
 }
 

--- a/scripts/add-services-to-hosts.sh
+++ b/scripts/add-services-to-hosts.sh
@@ -53,7 +53,7 @@ $INGRESS_IP  vault.eldertree.local
 $INGRESS_IP  grafana.eldertree.local
 $INGRESS_IP  prometheus.eldertree.local
 $INGRESS_IP  pihole.eldertree.local
-$INGRESS_IP  flux-ui.eldertree.local
+$INGRESS_IP  flux.eldertree.local
 $INGRESS_IP  docs.eldertree.local
 
 # Applications
@@ -80,7 +80,7 @@ echo "  - vault.eldertree.local"
 echo "  - grafana.eldertree.local"
 echo "  - prometheus.eldertree.local"
 echo "  - pihole.eldertree.local"
-echo "  - flux-ui.eldertree.local"
+echo "  - flux.eldertree.local"
 echo "  - docs.eldertree.local"
 echo "  - canopy.eldertree.local"
 echo "  - swimto.eldertree.local"

--- a/scripts/setup-caddy-proxy.sh
+++ b/scripts/setup-caddy-proxy.sh
@@ -52,7 +52,7 @@ $MARKER_START
 127.0.0.1  minio.eldertree.local
 127.0.0.1  swimto.eldertree.local
 127.0.0.1  pitanga.eldertree.local
-127.0.0.1  flux-ui.eldertree.local
+127.0.0.1  flux.eldertree.local
 127.0.0.1  pushgateway.eldertree.local
 127.0.0.1  pihole.eldertree.local
 


### PR DESCRIPTION
## Summary
- Renames the Flux UI (Weave GitOps) URL from `flux-ui.eldertree.local` to `flux.eldertree.local` for a cleaner, shorter URL
- Updates ingress host, helm chart defaults, hosts scripts, Caddy proxy config, and docs

## Files changed (8)
- `clusters/eldertree/observability/flux-ui-helmrelease.yaml` — ingress host + TLS
- `helm/flux-ui/values.yaml` — default host + TLS
- `helm/flux-ui/README.md` — documentation URLs
- `SERVICES_REFERENCE.md` — local URL reference
- `docs/eldertree-local-hosts-block.txt` — hosts template
- `scripts/add-services-to-hosts.sh` — hosts script
- `scripts/Caddyfile` — Caddy proxy host
- `scripts/setup-caddy-proxy.sh` — Caddy hosts entry

## Post-merge
After FluxCD reconciles, update local `/etc/hosts`:
```
sudo sed -i '' 's/flux-ui\.eldertree\.local/flux.eldertree.local/g' /etc/hosts
```

Made with [Cursor](https://cursor.com)