### PR TITLE
feat(observability): GitHub OAuth login for Flux UI via Dex

### DIFF
--- a/clusters/eldertree/observability/dex-externalsecret.yaml
+++ b/clusters/eldertree/observability/dex-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-github-client
+  namespace: observability
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: dex-github-client
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: secret/dex/github-oauth
+        property: client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: secret/dex/github-oauth
+        property: client-secret

--- a/clusters/eldertree/observability/dex-helmrelease.yaml
+++ b/clusters/eldertree/observability/dex-helmrelease.yaml
@@ -1,0 +1,88 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dex
+  namespace: observability
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: dex
+      version: "0.19.x"
+      sourceRef:
+        kind: HelmRepository
+        name: dex
+        namespace: observability
+      interval: 12h
+  install:
+    createNamespace: false
+  upgrade:
+    cleanupOnFail: true
+  values:
+    image:
+      tag: v2.41.1
+
+    # Inject GitHub OAuth credentials from Vault via ExternalSecret
+    envVars:
+      - name: GITHUB_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: dex-github-client
+            key: client-id
+      - name: GITHUB_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: dex-github-client
+            key: client-secret
+
+    config:
+      issuer: https://dex.eldertree.local
+
+      storage:
+        type: memory
+
+      # Weave GitOps as an OIDC client of Dex
+      staticClients:
+        - name: "Weave GitOps"
+          id: weave-gitops
+          secret: weave-gitops-dex-secret
+          redirectURIs:
+            - "https://flux.eldertree.local/oauth2/callback"
+
+      # GitHub as the identity provider
+      connectors:
+        - type: github
+          id: github
+          name: GitHub
+          config:
+            clientID: $GITHUB_CLIENT_ID
+            clientSecret: $GITHUB_CLIENT_SECRET
+            redirectURI: https://dex.eldertree.local/callback
+            # Restrict to your GitHub user
+            orgs:
+              - name: raolivei
+
+    # Resource limits for Raspberry Pi
+    resources:
+      limits:
+        cpu: 250m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+    # Ingress for Dex
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+      hosts:
+        - host: dex.eldertree.local
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: dex-tls
+          hosts:
+            - dex.eldertree.local

--- a/clusters/eldertree/observability/dex-helmrepository.yaml
+++ b/clusters/eldertree/observability/dex-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dex
+  namespace: observability
+spec:
+  interval: 24h
+  url: https://charts.dexidp.io

--- a/clusters/eldertree/observability/dex-rbac.yaml
+++ b/clusters/eldertree/observability/dex-rbac.yaml
@@ -1,0 +1,16 @@
+# ClusterRoleBinding: Grant GitHub org members full Weave GitOps access
+# Dex maps GitHub org membership to groups like "raolivei:*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-ui-github-admin
+subjects:
+  # Match any member of the raolivei GitHub org
+  - kind: Group
+    name: "raolivei"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/clusters/eldertree/observability/flux-ui-helmrelease.yaml
+++ b/clusters/eldertree/observability/flux-ui-helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/flux-ui
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: GitRepository
         name: flux-system
@@ -29,7 +29,12 @@ spec:
     # Values passed to weave-gitops dependency (gitops-server chart)
     weave-gitops:
       enabled: true
-      
+
+      # Image override: v0.39.0-rc.2 adds Flux v2 API support (fixes v2beta1 error)
+      image:
+        repository: ghcr.io/weaveworks/wego-app
+        tag: v0.39.0-rc.2
+
       # Service configuration
       service:
         type: ClusterIP
@@ -79,9 +84,15 @@ spec:
         create: true
         clusterRole: true
       
-      # Admin user configuration - required for authentication
+      # OIDC authentication via Dex + GitHub
+      # Disabling static admin user in favour of GitHub login
       adminUser:
-        create: true
-        createClusterRole: true
-        username: admin
-        passwordHash: "$2y$10$b9.2/PghT0wFR1VVeEt10.nJ6JxfKMAto5YpIFehLISdeeqP.PuQC" # Password: admin123
+        create: false
+
+      # Additional server args for OIDC
+      additionalArgs:
+        - --auth-methods=oidc
+        - --oidc-issuer-url=https://dex.eldertree.local
+        - --oidc-client-id=weave-gitops
+        - --oidc-client-secret=weave-gitops-dex-secret
+        - --oidc-redirect-url=https://flux.eldertree.local/oauth2/callback

--- a/clusters/eldertree/observability/kustomization.yaml
+++ b/clusters/eldertree/observability/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - pihole-scrape-config.yaml # Pi-hole Prometheus scrape configuration
   - visage-scrape-config.yaml # Visage metrics scrape configuration
   - vault-scrape-config.yaml # Vault telemetry scrape configuration
+  - dex-helmrepository.yaml # Dex Helm chart repository
+  - dex-externalsecret.yaml # GitHub OAuth credentials from Vault
+  - dex-helmrelease.yaml # Dex OIDC identity provider (GitHub auth)
+  - dex-rbac.yaml # RBAC for GitHub-authenticated users
   - flux-ui-helmrelease.yaml # Flux UI (Weave GitOps) for managing FluxCD resources
   - postgres-exporter.yaml # PostgreSQL metrics exporter for all DB instances
   - redis-exporter.yaml # Redis metrics exporter for all Redis instances

--- a/docs/eldertree-local-hosts-block.txt
+++ b/docs/eldertree-local-hosts-block.txt
@@ -15,6 +15,7 @@ TRAEFIK_LB_IP  canopy.eldertree.local
 TRAEFIK_LB_IP  pitanga.eldertree.local
 TRAEFIK_LB_IP  pushgateway.eldertree.local
 TRAEFIK_LB_IP  flux.eldertree.local
+TRAEFIK_LB_IP  dex.eldertree.local
 TRAEFIK_LB_IP  alertmanager.eldertree.local
 TRAEFIK_LB_IP  docs.eldertree.local
 TRAEFIK_LB_IP  journey.eldertree.local

--- a/helm/flux-ui/Chart.yaml
+++ b/helm/flux-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flux-ui
 description: Flux UI (Weave GitOps) for visualizing and managing FluxCD deployments
 type: application
-version: 0.1.1
-appVersion: "0.38.0"
+version: 0.2.0
+appVersion: "0.39.0-rc.2"
 dependencies:
   - name: weave-gitops
     version: "4.0.36"

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -99,6 +99,17 @@ flux.eldertree.local {
     }
 }
 
+# Dex (OIDC identity provider for Flux UI GitHub auth)
+dex.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.200 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host dex.eldertree.local
+    }
+}
+
 # Pushgateway (metrics push endpoint)
 pushgateway.eldertree.local {
     tls internal

--- a/scripts/add-services-to-hosts.sh
+++ b/scripts/add-services-to-hosts.sh
@@ -54,6 +54,7 @@ $INGRESS_IP  grafana.eldertree.local
 $INGRESS_IP  prometheus.eldertree.local
 $INGRESS_IP  pihole.eldertree.local
 $INGRESS_IP  flux.eldertree.local
+$INGRESS_IP  dex.eldertree.local
 $INGRESS_IP  docs.eldertree.local
 
 # Applications
@@ -81,6 +82,7 @@ echo "  - grafana.eldertree.local"
 echo "  - prometheus.eldertree.local"
 echo "  - pihole.eldertree.local"
 echo "  - flux.eldertree.local"
+echo "  - dex.eldertree.local"
 echo "  - docs.eldertree.local"
 echo "  - canopy.eldertree.local"
 echo "  - swimto.eldertree.local"

--- a/scripts/setup-caddy-proxy.sh
+++ b/scripts/setup-caddy-proxy.sh
@@ -53,6 +53,7 @@ $MARKER_START
 127.0.0.1  swimto.eldertree.local
 127.0.0.1  pitanga.eldertree.local
 127.0.0.1  flux.eldertree.local
+127.0.0.1  dex.eldertree.local
 127.0.0.1  pushgateway.eldertree.local
 127.0.0.1  pihole.eldertree.local
 


### PR DESCRIPTION
## Summary
- Deploys **Dex** as an OIDC identity provider with a GitHub connector, replacing the static  login
- Upgrades Weave GitOps image to **v0.39.0-rc.2** which fixes the `v2beta1` HelmRelease API error (HelmReleases weren't showing in the UI)
- After merge, login at `https://flux.eldertree.local` redirects to GitHub OAuth

## Architecture
```
flux.eldertree.local → "Login with OIDC" → dex.eldertree.local → GitHub OAuth → callback → logged in
```

## New files
- `dex-helmrepository.yaml` — Dex Helm chart source
- `dex-helmrelease.yaml` — Dex deployment with GitHub connector at `dex.eldertree.local`
- `dex-externalsecret.yaml` — GitHub OAuth creds from Vault (`secret/dex/github-oauth`)
- `dex-rbac.yaml` — ClusterRoleBinding for `raolivei` GitHub org → `cluster-admin`

## Modified files
- `flux-ui-helmrelease.yaml` — Image override to v0.39.0-rc.2 + OIDC args
- `Chart.yaml` — Bumped to 0.2.0 / appVersion 0.39.0-rc.2
- `kustomization.yaml` — Added 4 Dex resources
- Hosts/Caddy scripts — Added `dex.eldertree.local` entries

## Post-merge
Add to local `/etc/hosts`:
```
192.168.2.200  dex.eldertree.local
```

