### PR TITLE
fix(observability): resolve OIDC TLS and DNS for Flux UI GitHub auth

### DIFF
--- a/clusters/eldertree/core-infrastructure/coredns-custom.yaml
+++ b/clusters/eldertree/core-infrastructure/coredns-custom.yaml
@@ -1,0 +1,27 @@
+# Custom CoreDNS config to resolve *.eldertree.local inside the cluster.
+# Without this, pods can't reach ingress hostnames like dex.eldertree.local,
+# because CoreDNS only knows about cluster.local and upstream resolvers.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  eldertree.server: |
+    eldertree.local:53 {
+      errors
+      cache 30
+      hosts {
+        192.168.2.200 dex.eldertree.local
+        192.168.2.200 flux.eldertree.local
+        192.168.2.200 grafana.eldertree.local
+        192.168.2.200 prometheus.eldertree.local
+        192.168.2.200 vault.eldertree.local
+        192.168.2.200 swimto.eldertree.local
+        192.168.2.200 canopy.eldertree.local
+        192.168.2.200 pitanga.eldertree.local
+        192.168.2.200 docs.eldertree.local
+        192.168.2.200 openclaw.eldertree.local
+        fallthrough
+      }
+    }

--- a/clusters/eldertree/core-infrastructure/kustomization.yaml
+++ b/clusters/eldertree/core-infrastructure/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - cert-manager # TLS certificate management using cert-manager
   - coredns-autoscaler # Auto-scales CoreDNS for HA (min 2 replicas)
+  - coredns-custom.yaml # Resolve *.eldertree.local inside the cluster
   - issuers # ClusterIssuer resources (self-signed certificates)
   # MetalLB removed - kube-vip now handles LoadBalancer services
   - pod-disruption-budgets # PDBs for critical infrastructure components

--- a/clusters/eldertree/observability/flux-ui-helmrelease.yaml
+++ b/clusters/eldertree/observability/flux-ui-helmrelease.yaml
@@ -96,3 +96,4 @@ spec:
         - --oidc-client-id=weave-gitops
         - --oidc-client-secret=weave-gitops-dex-secret
         - --oidc-redirect-url=https://flux.eldertree.local/oauth2/callback
+        - --insecure


### PR DESCRIPTION
## Summary
Follow-up to #133. Fixes two issues preventing Weave GitOps from connecting to Dex:

1. **DNS**: Pods couldn't resolve `dex.eldertree.local` via CoreDNS (only knew `cluster.local`). Added a `coredns-custom` ConfigMap with static hosts for `*.eldertree.local` → Traefik VIP (`192.168.2.200`)
2. **TLS**: Self-signed cert from cert-manager wasn't trusted by the Weave GitOps pod. Added `--insecure` flag to skip verification for the internal OIDC issuer connection

## Files
- `flux-ui-helmrelease.yaml` — Added `--insecure` flag
- `core-infrastructure/coredns-custom.yaml` — New: static DNS for `*.eldertree.local` inside cluster
- `core-infrastructure/kustomization.yaml` — Added coredns-custom resource

Made with [Cursor](https://cursor.com)