### PR TITLE
chore(observability): move Flux UI password to Vault

### DIFF
--- a/clusters/eldertree/observability/flux-ui-externalsecret.yaml
+++ b/clusters/eldertree/observability/flux-ui-externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: flux-ui-admin
+  namespace: observability
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: flux-ui-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: password-hash
+      remoteRef:
+        key: secret/flux-ui/admin
+        property: password-hash

--- a/clusters/eldertree/observability/flux-ui-helmrelease.yaml
+++ b/clusters/eldertree/observability/flux-ui-helmrelease.yaml
@@ -19,6 +19,12 @@ spec:
     createNamespace: false
   upgrade:
     cleanupOnFail: true
+  # Inject admin password hash from Vault (via ExternalSecret)
+  valuesFrom:
+    - kind: Secret
+      name: flux-ui-admin
+      valuesKey: password-hash
+      targetPath: weave-gitops.adminUser.passwordHash
   values:
     # Global configuration
     global:
@@ -84,10 +90,8 @@ spec:
         create: true
         clusterRole: true
       
-      # Static admin user
+      # Static admin user (password hash injected from Vault via valuesFrom)
       adminUser:
         create: true
         createClusterRole: true
         username: admin
-        # Password: eldertree2026
-        passwordHash: "$2b$10$0e.ArIfqhaYjJ7LiUDO9keg47pCzHJxB632/9s6b6hhNjW0pSXJqa"

--- a/clusters/eldertree/observability/kustomization.yaml
+++ b/clusters/eldertree/observability/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - pihole-scrape-config.yaml # Pi-hole Prometheus scrape configuration
   - visage-scrape-config.yaml # Visage metrics scrape configuration
   - vault-scrape-config.yaml # Vault telemetry scrape configuration
+  - flux-ui-externalsecret.yaml # Flux UI admin password from Vault
   - flux-ui-helmrelease.yaml # Flux UI (Weave GitOps) for managing FluxCD resources
   - postgres-exporter.yaml # PostgreSQL metrics exporter for all DB instances
   - redis-exporter.yaml # Redis metrics exporter for all Redis instances

--- a/helm/flux-ui/values.yaml
+++ b/helm/flux-ui/values.yaml
@@ -62,9 +62,9 @@ weave-gitops:
     clusterRole: true
   
   # Admin user configuration - required for authentication
+  # passwordHash is injected from Vault via ExternalSecret + valuesFrom in the HelmRelease
   adminUser:
     create: true
     createClusterRole: true
     username: admin
-    passwordHash: "$2y$10$b9.2/PghT0wFR1VVeEt10.nJ6JxfKMAto5YpIFehLISdeeqP.PuQC" # Password: admin123
 


### PR DESCRIPTION
## Summary
- Remove hardcoded admin password hash from Git (both HelmRelease and Helm chart default values)
- Add `flux-ui-externalsecret.yaml` to pull the password hash from Vault (`secret/flux-ui/admin`)
- Inject the hash into the HelmRelease via `valuesFrom` → `weave-gitops.adminUser.passwordHash`

Follow-up to PR #135 which simplified auth but still had the password hash in Git.

## Test plan
- [x] Verify `flux-ui-admin` ExternalSecret syncs successfully
- [x] Verify Flux UI login still works with `admin` / `eldertree2026`


Made with [Cursor](https://cursor.com)