### PR TITLE
feat(openclaw): add Grove ingress and deployment fixes

### DIFF
--- a/SERVICES_REFERENCE.md
+++ b/SERVICES_REFERENCE.md
@@ -193,6 +193,17 @@ dig @192.168.2.201 grafana.eldertree.local
 | **Credentials**  | Stored in Vault: `secret/openclaw/*`               |
 | **Setup Script** | `./scripts/setup-openclaw.sh`                      |
 
+### Grove (AI Agent)
+
+| Property         | Value                                              |
+| ---------------- | -------------------------------------------------- |
+| **Local URL**    | `https://grove.eldertree.local`                    |
+| **Swagger Docs** | `https://grove.eldertree.local/docs`               |
+| **Namespace**    | `openclaw`                                         |
+| **API Port**     | 8006                                               |
+| **Role**         | AI agent sidecar for cluster management & code ops |
+| **Credentials**  | Stored in Vault: `secret/grove/*`                  |
+
 ---
 
 ## 🌐 Public Services (Pitanga LLC)
@@ -318,6 +329,8 @@ cat vault-backup-YYYYMMDD.json | jq '.secrets'
 - `secret/openclaw/gemini` - OpenClaw Google AI Studio API key
 - `secret/openclaw/gateway` - OpenClaw gateway authentication token
 - `secret/openclaw/brave` - OpenClaw Brave Search API key (web search)
+- `secret/grove/github-app` - Grove GitHub App credentials (app-id, installation-id, private-key)
+- `secret/grove/api-key` - Grove API authentication key
 
 ### Pitanga
 

--- a/clusters/eldertree/openclaw/grove-deployment.yaml
+++ b/clusters/eldertree/openclaw/grove-deployment.yaml
@@ -39,6 +39,9 @@ spec:
             capabilities:
               drop:
                 - ALL
+          envFrom:
+            - configMapRef:
+                name: grove-config
           env:
             - name: GROVE_PORT
               value: "8006"

--- a/clusters/eldertree/openclaw/grove-ingress.yaml
+++ b/clusters/eldertree/openclaw/grove-ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grove
+  namespace: openclaw
+  labels:
+    app: openclaw
+    component: grove
+  annotations:
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - grove.eldertree.local
+      secretName: grove-tls
+  rules:
+    - host: grove.eldertree.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grove
+                port:
+                  number: 8000

--- a/clusters/eldertree/openclaw/kustomization.yaml
+++ b/clusters/eldertree/openclaw/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - grove-configmap.yaml
   - grove-deployment.yaml
   - grove-service.yaml
+  - grove-ingress.yaml
   - grove-image-repo.yaml
   - grove-image-policy.yaml
   - grove-image-update.yaml

--- a/docs/eldertree-local-hosts-block.txt
+++ b/docs/eldertree-local-hosts-block.txt
@@ -17,6 +17,7 @@ TRAEFIK_LB_IP  pushgateway.eldertree.local
 TRAEFIK_LB_IP  flux.eldertree.local
 TRAEFIK_LB_IP  alertmanager.eldertree.local
 TRAEFIK_LB_IP  docs.eldertree.local
+TRAEFIK_LB_IP  grove.eldertree.local
 TRAEFIK_LB_IP  journey.eldertree.local
 TRAEFIK_LB_IP  nima.eldertree.local
 

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -110,6 +110,17 @@ pushgateway.eldertree.local {
     }
 }
 
+# Grove (AI agent API + Swagger docs)
+grove.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host grove.eldertree.local
+    }
+}
+
 # Pi-hole (DNS admin - may not work via ingress)
 pihole.eldertree.local {
     tls internal

--- a/scripts/add-services-to-hosts.sh
+++ b/scripts/add-services-to-hosts.sh
@@ -54,6 +54,7 @@ $INGRESS_IP  grafana.eldertree.local
 $INGRESS_IP  prometheus.eldertree.local
 $INGRESS_IP  pihole.eldertree.local
 $INGRESS_IP  flux.eldertree.local
+$INGRESS_IP  grove.eldertree.local
 $INGRESS_IP  docs.eldertree.local
 
 # Applications
@@ -81,6 +82,7 @@ echo "  - grafana.eldertree.local"
 echo "  - prometheus.eldertree.local"
 echo "  - pihole.eldertree.local"
 echo "  - flux.eldertree.local"
+echo "  - grove.eldertree.local"
 echo "  - docs.eldertree.local"
 echo "  - canopy.eldertree.local"
 echo "  - swimto.eldertree.local"

--- a/scripts/setup-caddy-proxy.sh
+++ b/scripts/setup-caddy-proxy.sh
@@ -53,6 +53,7 @@ $MARKER_START
 127.0.0.1  swimto.eldertree.local
 127.0.0.1  pitanga.eldertree.local
 127.0.0.1  flux.eldertree.local
+127.0.0.1  grove.eldertree.local
 127.0.0.1  pushgateway.eldertree.local
 127.0.0.1  pihole.eldertree.local
 


### PR DESCRIPTION
## Summary
- Add `grove-ingress.yaml` to expose Grove at `https://grove.eldertree.local` (Swagger docs at `/docs`)
- Fix ConfigMap not referenced: add `envFrom: configMapRef` for `grove-config` in deployment
- Add `grove.eldertree.local` to hosts template, Caddy proxy, and setup scripts
- Add Grove service entry and Vault paths to `SERVICES_REFERENCE.md`

## Test plan
- [ ] FluxCD reconciles without errors
- [ ] `kubectl get ingress -n openclaw` shows `grove` ingress
- [ ] `https://grove.eldertree.local/health` returns 200 (after Caddy/hosts update)
- [ ] `GROVE_GITHUB_OWNER` and `GROVE_REPO_SYNC_INTERVAL_HOURS` env vars visible in pod


Made with [Cursor](https://cursor.com)