### PR TITLE
fix(flux): replace deprecated .Updated template with .Changed

### DIFF
--- a/clusters/eldertree/canopy/image-automation.yaml
+++ b/clusters/eldertree/canopy/image-automation.yaml
@@ -64,7 +64,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(canopy): update images to {{range .Updated.Images}}{{println .}}{{end}}"
+      messageTemplate: "chore(canopy): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/journey/image-automation.yaml
+++ b/clusters/eldertree/journey/image-automation.yaml
@@ -64,7 +64,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(journey): update images to {{range .Updated.Images}}{{println .}}{{end}}"
+      messageTemplate: "chore(journey): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/nima/image-automation.yaml
+++ b/clusters/eldertree/nima/image-automation.yaml
@@ -41,7 +41,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(nima): update images to {{range .Updated.Images}}{{println .}}{{end}}"
+      messageTemplate: "chore(nima): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/openclaw/grove-image-update.yaml
+++ b/clusters/eldertree/openclaw/grove-image-update.yaml
@@ -18,7 +18,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(grove): update image to {{range .Updated.Images}}{{println .}}{{end}}"
+      messageTemplate: "chore(grove): update image to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/pitanga/image-automation.yaml
+++ b/clusters/eldertree/pitanga/image-automation.yaml
@@ -41,7 +41,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: 'chore(pitanga): update pitanga-website image to {{range .Updated.Images}}{{println .}}{{end}}'
+      messageTemplate: "chore(pitanga): update pitanga-website image to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/swimto/image-update-automation.yaml
+++ b/clusters/eldertree/swimto/image-update-automation.yaml
@@ -18,7 +18,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(swimto): update images to {{range .Updated.Images}}{{println .}}{{end}}"
+      messageTemplate: "chore(swimto): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
     push:
       branch: main
   update:


### PR DESCRIPTION
## Summary
- Replace `.Updated.Images` with `.Changed.Objects` / `.NewValue` in all 6 `ImageUpdateAutomation` message templates
- Affects: grove, swimto, canopy, journey, nima, pitanga
- FluxCD image-reflector-controller v1 removed the `.Updated` field, causing all automations to fail with: `template uses removed '.Updated' field`

## Test plan
- [ ] All `ImageUpdateAutomation` resources show `Ready: True` after reconciliation
- [ ] Grove image auto-updates to `v0.2.0` in Git


Made with [Cursor](https://cursor.com)