### PR TITLE
fix(pihole): use loadBalancerClass to prevent K3s ServiceLB conflicts

### DIFF
--- a/helm/pi-hole/templates/service.yaml
+++ b/helm/pi-hole/templates/service.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     {{- include "pi-hole.labels" . | nindent 4 }}
   annotations:
-    # CRITICAL: Disable K3s built-in ServiceLB (Klipper) since we use kube-vip
-    # Without this, k3s will create svclb DaemonSet pods that conflict with port 53
-    # This annotation MUST be present to prevent port conflicts and scheduling issues
-    # Using both annotation formats for maximum compatibility
-    svc.k3s.cattle.io/loadbalancer-proxy: "false"
-    service.beta.kubernetes.io/k3s-lb: "false"
-    # kube-vip reads loadBalancerIP from spec.loadBalancerIP
+    # kube-vip: tell kube-vip which IP to assign (preferred over deprecated spec.loadBalancerIP)
+    {{- if .Values.service.loadBalancerIP }}
+    kube-vip.io/loadbalancerIPs: {{ .Values.service.loadBalancerIP | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerClass }}
+  # loadBalancerClass tells K3s ServiceLB to ignore this service entirely,
+  # preventing it from creating svclb DaemonSet pods that conflict with port 53.
+  # Without this, K3s ServiceLB creates Pending pods and blocks the external IP assignment.
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/helm/pi-hole/values.yaml
+++ b/helm/pi-hole/values.yaml
@@ -18,7 +18,12 @@ image:
 
 service:
   type: LoadBalancer
-  # kube-vip will assign this IP (replaces MetalLB)
+  # Setting a loadBalancerClass prevents K3s built-in ServiceLB (Klipper) from
+  # creating svclb DaemonSet pods for this service. Without this, K3s ServiceLB
+  # tries to bind host port 53 (conflicting with CoreDNS), the svclb pods get
+  # stuck Pending, and the service never gets an EXTERNAL-IP — breaking DNS.
+  loadBalancerClass: kube-vip.io/kube-vip
+  # kube-vip will assign this IP via the kube-vip.io/loadbalancerIPs annotation
   # This IP should be configured as the DNS server on your router
   loadBalancerIP: 192.168.2.201
   dnsUdpPort: 53
@@ -28,11 +33,8 @@ service:
   httpPort: 80
   httpsPort: 443
   metricsPort: 9617
-  # NodePort for external access if LoadBalancer doesn't get an IP
-  # NOTE: These are only used when service.type is NodePort
-  # When using LoadBalancer, MetalLB handles external access and NodePorts are not needed
-  # However, k3s may still allocate them - the svc.k3s.cattle.io/loadbalancer-proxy: "false"
-  # annotation prevents k3s ServiceLB from creating conflicting DaemonSet pods
+  # NodePort values - K3s auto-allocates these for LoadBalancer services.
+  # They serve as a fallback if the LoadBalancer VIP is unreachable.
   dnsNodePort: 30053
   httpNodePort: 30080
   httpsNodePort: 30443


### PR DESCRIPTION
## Summary

- Adds `spec.loadBalancerClass: kube-vip.io/kube-vip` to the Pi-hole Service to prevent K3s ServiceLB (Klipper) from creating svclb DaemonSet pods that conflict with port 53
- Replaces ineffective K3s annotations (`svc.k3s.cattle.io/loadbalancer-proxy`, `service.beta.kubernetes.io/k3s-lb`) with the correct mechanism — those annotations don't actually prevent svclb DaemonSet creation
- Adds `kube-vip.io/loadbalancerIPs` annotation as the preferred way to specify the VIP (upstream `spec.loadBalancerIP` is deprecated)

## Problem

K3s ServiceLB was creating `svclb-pi-hole-*` pods that couldn't schedule because host port 53 was already in use. With all svclb pods stuck in `Pending`, the Service never got its `EXTERNAL-IP` assigned (`<pending>`). Even though kube-vip advertised the VIP at the network layer (ping worked), kube-proxy had no iptables rules to forward DNS traffic to the Pi-hole pod — causing all DNS queries to time out and breaking ad blocking.

## How it works

Setting `loadBalancerClass` to a non-default value makes K3s ServiceLB completely skip this service (no svclb DaemonSet, no status overwrites). kube-vip v0.8.3 has no `--lb-class-only` flag, so it continues to manage all LoadBalancer services regardless of class.

## Test plan

- [ ] FluxCD reconciles the Helm upgrade successfully
- [ ] `kubectl get svc pi-hole -n pihole` shows `EXTERNAL-IP: 192.168.2.201`
- [ ] No `svclb-pi-hole-*` pods are created in `kube-system`
- [ ] `dig @192.168.2.201 google.com` resolves successfully
- [ ] `dig @192.168.2.201 ads.google.com` returns `0.0.0.0` (blocked)
- [ ] DNS survives a kube-vip pod restart


Made with [Cursor](https://cursor.com)