### PR TITLE
fix: resolve FluxCD image automation, Grove deployment, and SwimTO routing

### DIFF
--- a/clusters/eldertree/canopy/image-automation.yaml
+++ b/clusters/eldertree/canopy/image-automation.yaml
@@ -64,7 +64,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(canopy): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
+      messageTemplate: "chore(canopy): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/journey/image-automation.yaml
+++ b/clusters/eldertree/journey/image-automation.yaml
@@ -64,7 +64,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(journey): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
+      messageTemplate: "chore(journey): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/nima/image-automation.yaml
+++ b/clusters/eldertree/nima/image-automation.yaml
@@ -41,7 +41,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(nima): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
+      messageTemplate: "chore(nima): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -40,7 +40,14 @@ data:
         "mode": "local",
         "bind": "0.0.0.0",
         "port": 18789,
-        "trustedProxies": ["10.42.0.0/16", "10.43.0.0/16"]
+        "trustedProxies": ["10.42.0.0/16", "10.43.0.0/16"],
+        "http": {
+          "endpoints": {
+            "chatCompletions": {
+              "enabled": true
+            }
+          }
+        }
       },
       "agents": {
         "defaults": {

--- a/clusters/eldertree/openclaw/grove-deployment.yaml
+++ b/clusters/eldertree/openclaw/grove-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       app: openclaw
       component: grove
   strategy:
-    type: Recreate  # Use Recreate since we have a PVC
+    type: Recreate # Use Recreate since we have a PVC
   template:
     metadata:
       labels:
@@ -29,7 +29,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: grove
-          image: ghcr.io/raolivei/grove:0.1.0  # {"$imagepolicy": "openclaw:grove"}
+          image: ghcr.io/raolivei/grove:v0.2.0 # {"$imagepolicy": "openclaw:grove"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8006

--- a/clusters/eldertree/openclaw/grove-image-update.yaml
+++ b/clusters/eldertree/openclaw/grove-image-update.yaml
@@ -18,7 +18,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(grove): update image to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
+      messageTemplate: "chore(grove): update image{{range .Changed.Changes}} {{.NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/pitanga/image-automation.yaml
+++ b/clusters/eldertree/pitanga/image-automation.yaml
@@ -41,7 +41,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(pitanga): update pitanga-website image to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
+      messageTemplate: "chore(pitanga): update pitanga-website image{{range .Changed.Changes}} {{.NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/swimto/image-update-automation.yaml
+++ b/clusters/eldertree/swimto/image-update-automation.yaml
@@ -18,7 +18,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(swimto): update images to {{range .Changed.Objects}}{{println .NewValue}}{{end}}"
+      messageTemplate: "chore(swimto): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
     push:
       branch: main
   update:

--- a/clusters/eldertree/swimto/ingress.yaml
+++ b/clusters/eldertree/swimto/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   replacePathRegex:
     regex: "^/api(/.*?)/?$"
-    replacement: "$1/"
+    replacement: "$1"
 ---
 
 apiVersion: traefik.io/v1alpha1


### PR DESCRIPTION
## Summary

- **Fix FluxCD ImageUpdateAutomation templates** across all 6 apps (canopy, journey, nima, grove, pitanga, swimto) — replaced broken `.Changed.Objects` with `.Changed.Changes` so auto-image updates can commit again
- **Update Grove deployment** from `0.1.0` to `v0.2.0` — fixes `ModuleNotFoundError` caused by pip installing to wrong path in the old Dockerfile
- **Enable OpenClaw chatCompletions endpoint** — allows terminal/API interaction with the LLM gateway
- **Fix SwimTO Traefik middleware** — removed trailing slash in `replacePathRegex` replacement that was causing 404s on `/api/schedule` for mobile clients

## Test plan

- [x] Verified SwimTO schedule API returns data on all 3 domains (swimto.app, swimto.eldertree.xyz, swimto.eldertree.local)
- [x] Verified Grove pod running with v0.2.0 image
- [x] Verified OpenClaw chat completions endpoint responds via terminal `grove` command
- [x] Verified FluxCD ImageUpdateAutomation resources no longer error on template rendering

Made with [Cursor](https://cursor.com)