### PR TITLE
fix(monitoring): correct Traefik service label selectors in SwimTO dashboard

### DIFF
--- a/helm/monitoring-stack/dashboards/swimto-dashboard.json
+++ b/helm/monitoring-stack/dashboards/swimto-dashboard.json
@@ -8,7 +8,7 @@
   ],
   "timezone": "",
   "schemaVersion": 38,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
   "panels": [
     {
@@ -23,7 +23,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(traefik_service_requests_total{namespace=\"swimto\", service=\"swimto-api-service\"}[5m])) by (code)",
+          "expr": "sum(rate(traefik_service_requests_total{namespace=\"swimto\", service=~\".*swimto-api-service.*\"}[5m])) by (code)",
           "legendFormat": "HTTP {{code}}"
         }
       ]
@@ -40,7 +40,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"swimto\", service=\"swimto-api-service\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"swimto\", service=~\".*swimto-api-service.*\"}[5m])) by (le))",
           "legendFormat": "p95"
         }
       ]
@@ -57,7 +57,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(traefik_service_requests_total{namespace=\"swimto\", service=\"swimto-web-service\"}[5m])) by (code)",
+          "expr": "sum(rate(traefik_service_requests_total{namespace=\"swimto\", service=~\".*swimto-web-service.*\"}[5m])) by (code)",
           "legendFormat": "HTTP {{code}}"
         }
       ]


### PR DESCRIPTION
## Summary

- Fix Traefik service label selectors in SwimTO Grafana dashboard
- Traefik uses fully-qualified names like `swimto-swimto-api-service-8000@kubernetes` but the dashboard was exact-matching on `swimto-api-service`, causing "No data" on API Request Rate, API Response Time (p95), and Web Request Rate panels

## Test plan

- [ ] Verify API Request Rate panel shows data after deployment
- [ ] Verify API Response Time (p95) panel shows data
- [ ] Verify Web Request Rate panel shows data

Made with [Cursor](https://cursor.com)