### PR TITLE
fix(monitoring): bump monitoring-stack chart to v0.2.0

### DIFF
--- a/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
+++ b/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/monitoring-stack
-      version: "0.1.0"
+      version: "0.2.0"
       sourceRef:
         kind: GitRepository
         name: flux-system

--- a/helm/monitoring-stack/Chart.yaml
+++ b/helm/monitoring-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring-stack
 description: Complete monitoring stack with Prometheus and Grafana for pi-fleet
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0"
 dependencies:
   - name: prometheus


### PR DESCRIPTION
## Summary

- Bump monitoring-stack chart version from 0.1.0 to 0.2.0 to trigger Helm upgrade
- The HelmRelease uses `reconcileStrategy: ChartVersion`, so the dashboard JSON fix from PR #142 won't deploy without a version bump

## Test plan

- [ ] Verify FluxCD triggers Helm upgrade after merge
- [ ] Verify SwimTO Grafana dashboard panels show data

Made with [Cursor](https://cursor.com)