### PR TITLE
fix: resolve infrastructure inconsistencies across all namespaces

### DIFF
--- a/clusters/eldertree/canopy/deploy.yaml
+++ b/clusters/eldertree/canopy/deploy.yaml
@@ -27,9 +27,18 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: api
           image: ghcr.io/raolivei/canopy-api:v0.4.0 # {"$imagepolicy": "canopy:canopy-api-policy"}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8000
               name: http
@@ -86,9 +95,18 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: frontend
           image: ghcr.io/raolivei/canopy-frontend:v0.4.0 # {"$imagepolicy": "canopy:canopy-frontend-policy"}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 3000
               name: http

--- a/clusters/eldertree/canopy/ingress.yaml
+++ b/clusters/eldertree/canopy/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: canopy
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd,canopy-canopy-basic-auth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: canopy-redirect-https@kubernetescrd,canopy-canopy-basic-auth@kubernetescrd
     cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
   labels:
     app: canopy

--- a/clusters/eldertree/canopy/middleware.yaml
+++ b/clusters/eldertree/canopy/middleware.yaml
@@ -4,7 +4,7 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: redirect-https
-  namespace: default
+  namespace: canopy
 spec:
   redirectScheme:
     scheme: https

--- a/clusters/eldertree/eldertree-docs/ingress.yaml
+++ b/clusters/eldertree/eldertree-docs/ingress.yaml
@@ -7,8 +7,13 @@ metadata:
     app.kubernetes.io/name: eldertree-docs
     app.kubernetes.io/component: documentation
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
 spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - docs.eldertree.local
+      secretName: eldertree-docs-tls
   rules:
     - host: docs.eldertree.local
       http:

--- a/clusters/eldertree/journey/api-deployment.yaml
+++ b/clusters/eldertree/journey/api-deployment.yaml
@@ -20,9 +20,18 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: api
           image: ghcr.io/raolivei/journey-api:v0.2.0 # {"$imagepolicy": "journey:journey-api-policy"}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8000
               name: http
@@ -41,7 +50,7 @@ spec:
             - name: ENVIRONMENT
               value: "production"
             - name: CORS_ORIGINS
-              value: "https://journey.yourdomain.com"
+              value: "https://journey.eldertree.local"
           resources:
             requests:
               memory: "512Mi"

--- a/clusters/eldertree/journey/frontend-deployment.yaml
+++ b/clusters/eldertree/journey/frontend-deployment.yaml
@@ -20,9 +20,18 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: frontend
           image: ghcr.io/raolivei/journey-frontend:v0.2.0 # {"$imagepolicy": "journey:journey-frontend-policy"}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 80
               name: http

--- a/clusters/eldertree/journey/ingress.yaml
+++ b/clusters/eldertree/journey/ingress.yaml
@@ -6,17 +6,15 @@ metadata:
   labels:
     app: journey
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   tls:
     - hosts:
-        - journey.yourdomain.com
+        - journey.eldertree.local
       secretName: journey-tls
   rules:
-    - host: journey.yourdomain.com
+    - host: journey.eldertree.local
       http:
         paths:
           # API routes

--- a/clusters/eldertree/nima/deploy-frontend.yaml
+++ b/clusters/eldertree/nima/deploy-frontend.yaml
@@ -21,10 +21,19 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: frontend
           image: ghcr.io/raolivei/nima-frontend:latest
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 3000
               name: http

--- a/clusters/eldertree/nima/deploy.yaml
+++ b/clusters/eldertree/nima/deploy.yaml
@@ -21,10 +21,19 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: api
           image: ghcr.io/raolivei/nima-api:v0.5.0 # {"$imagepolicy": "nima:nima-api-policy"}
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8000
               name: http

--- a/clusters/eldertree/nima/ingress.yaml
+++ b/clusters/eldertree/nima/ingress.yaml
@@ -1,4 +1,14 @@
 ---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-https
+  namespace: nima
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,7 +16,7 @@ metadata:
   namespace: nima
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: nima-redirect-https@kubernetescrd
     cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
   labels:
     app: nima

--- a/clusters/eldertree/nima/kustomization.yaml
+++ b/clusters/eldertree/nima/kustomization.yaml
@@ -11,7 +11,3 @@ resources:
   - image-automation.yaml
 
 
-
-
-
-

--- a/clusters/eldertree/openclaw/grove-image-policy.yaml
+++ b/clusters/eldertree/openclaw/grove-image-policy.yaml
@@ -8,4 +8,4 @@ spec:
     name: grove
   policy:
     semver:
-      range: ">=0.1.0"
+      range: ">=0.1.0 <1.0.0"

--- a/clusters/eldertree/pitanga/image-automation.yaml
+++ b/clusters/eldertree/pitanga/image-automation.yaml
@@ -20,7 +20,7 @@ spec:
     name: pitanga-website
   policy:
     semver:
-      range: '>=0.1.0'
+      range: '>=0.1.0 <1.0.0'
 ---
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation

--- a/clusters/eldertree/pitanga/northwaysignal-deployment.yaml
+++ b/clusters/eldertree/pitanga/northwaysignal-deployment.yaml
@@ -17,10 +17,19 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: website
           image: ghcr.io/raolivei/northwaysignal-website:latest
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 5000
               name: http

--- a/clusters/eldertree/pitanga/website-ingress.yaml
+++ b/clusters/eldertree/pitanga/website-ingress.yaml
@@ -1,4 +1,14 @@
 ---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-https
+  namespace: pitanga
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
 # Local domain Ingress (pitanga.eldertree.local)
 # ExternalDNS annotation ensures DNS record is created in Pi-hole via RFC2136
 apiVersion: networking.k8s.io/v1
@@ -8,7 +18,7 @@ metadata:
   namespace: pitanga
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: pitanga-redirect-https@kubernetescrd
     cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
     external-dns.alpha.kubernetes.io/hostname: pitanga.eldertree.local
   labels:


### PR DESCRIPTION
## Summary

Full infrastructure consistency audit and fix across all app namespaces.

### Ingress fixes
- **Journey**: switched from `nginx` to `traefik` ingress controller, replaced placeholder `journey.yourdomain.com` with `journey.eldertree.local`, switched cert-manager issuer from `letsencrypt-prod` to `selfsigned-cluster-issuer`
- **Eldertree-docs**: added missing TLS, `ingressClassName: traefik`, and cert-manager annotation
- **Canopy/Pitanga/Nima**: moved shared `redirect-https` middleware from `default` namespace into each app's own namespace (consistent with swimto and openclaw which already had their own)

### Security hardening (7 deployments)
- Added pod-level `securityContext` (runAsNonRoot, runAsUser, fsGroup) and container-level `securityContext` (allowPrivilegeEscalation: false, drop ALL capabilities) to:
  - canopy-api, canopy-frontend
  - journey-api, journey-frontend
  - nima-api, nima-frontend
  - northwaysignal-website

### FluxCD consistency
- Added `<1.0.0` upper bound to pitanga and grove semver image policies (matching all other apps)

### Cleanup
- Removed trailing blank lines in nima/kustomization.yaml
- Fixed journey CORS_ORIGINS placeholder

## Test plan

- [ ] Verify canopy.eldertree.local still loads (redirect-https middleware moved)
- [ ] Verify pitanga.eldertree.local still loads (redirect-https middleware moved)
- [ ] Verify journey.eldertree.local resolves (new domain)
- [ ] Verify docs.eldertree.local gets TLS certificate
- [ ] Verify nima/journey/canopy pods start with new securityContext (no permission errors)
- [ ] Verify FluxCD image policies still resolve correctly


Made with [Cursor](https://cursor.com)