### PR TITLE
feat: add Dex OIDC for Flux UI and CoreDNS custom config

### DIFF
--- a/SERVICES_REFERENCE.md
+++ b/SERVICES_REFERENCE.md
@@ -117,13 +117,13 @@ dig @192.168.2.201 grafana.eldertree.local
 
 ### FluxCD (GitOps UI)
 
-| Property           | Value                                           |
-| ------------------ | ----------------------------------------------- |
+| Property           | Value                                        |
+| ------------------ | -------------------------------------------- |
 | **Local URL**      | `https://flux.eldertree.local` (if deployed) |
-| **Namespace**      | `flux-system`                                   |
-| **Git Repository** | `https://github.com/raolivei/pi-fleet`          |
-| **Branch**         | `main`                                          |
-| **Path**           | `clusters/eldertree/`                           |
+| **Namespace**      | `flux-system`                                |
+| **Git Repository** | `https://github.com/raolivei/pi-fleet`       |
+| **Branch**         | `main`                                       |
+| **Path**           | `clusters/eldertree/`                        |
 
 ### Eldertree Docs
 

--- a/clusters/eldertree/core-infrastructure/coredns-custom.yaml
+++ b/clusters/eldertree/core-infrastructure/coredns-custom.yaml
@@ -1,0 +1,27 @@
+# Custom CoreDNS config to resolve *.eldertree.local inside the cluster.
+# Without this, pods can't reach ingress hostnames like dex.eldertree.local,
+# because CoreDNS only knows about cluster.local and upstream resolvers.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  eldertree.server: |
+    eldertree.local:53 {
+      errors
+      cache 30
+      hosts {
+        192.168.2.200 dex.eldertree.local
+        192.168.2.200 flux.eldertree.local
+        192.168.2.200 grafana.eldertree.local
+        192.168.2.200 prometheus.eldertree.local
+        192.168.2.200 vault.eldertree.local
+        192.168.2.200 swimto.eldertree.local
+        192.168.2.200 canopy.eldertree.local
+        192.168.2.200 pitanga.eldertree.local
+        192.168.2.200 docs.eldertree.local
+        192.168.2.200 openclaw.eldertree.local
+        fallthrough
+      }
+    }

--- a/clusters/eldertree/core-infrastructure/kustomization.yaml
+++ b/clusters/eldertree/core-infrastructure/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - storage-class-nvme.yaml # NVMe/SATA storage class for main node (high-performance)
   - storage-class-sd.yaml # SD card storage class for worker nodes
   - traefik-config.yaml # HA Traefik with 2 replicas for graceful node drains
+  - coredns-custom.yaml # Custom DNS: resolve *.eldertree.local inside the cluster

--- a/clusters/eldertree/observability/dex-externalsecret.yaml
+++ b/clusters/eldertree/observability/dex-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-github-client
+  namespace: observability
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: dex-github-client
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: secret/dex/github-oauth
+        property: client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: secret/dex/github-oauth
+        property: client-secret

--- a/clusters/eldertree/observability/dex-helmrelease.yaml
+++ b/clusters/eldertree/observability/dex-helmrelease.yaml
@@ -1,0 +1,88 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dex
+  namespace: observability
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: dex
+      version: "0.19.x"
+      sourceRef:
+        kind: HelmRepository
+        name: dex
+        namespace: observability
+      interval: 12h
+  install:
+    createNamespace: false
+  upgrade:
+    cleanupOnFail: true
+  values:
+    image:
+      tag: v2.41.1
+
+    # Inject GitHub OAuth credentials from Vault via ExternalSecret
+    envVars:
+      - name: GITHUB_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: dex-github-client
+            key: client-id
+      - name: GITHUB_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: dex-github-client
+            key: client-secret
+
+    config:
+      issuer: https://dex.eldertree.local
+
+      storage:
+        type: memory
+
+      # Weave GitOps as an OIDC client of Dex
+      staticClients:
+        - name: "Weave GitOps"
+          id: weave-gitops
+          secret: weave-gitops-dex-secret
+          redirectURIs:
+            - "https://flux.eldertree.local/oauth2/callback"
+
+      # GitHub as the identity provider
+      connectors:
+        - type: github
+          id: github
+          name: GitHub
+          config:
+            clientID: $GITHUB_CLIENT_ID
+            clientSecret: $GITHUB_CLIENT_SECRET
+            redirectURI: https://dex.eldertree.local/callback
+            # Restrict to your GitHub user
+            orgs:
+              - name: raolivei
+
+    # Resource limits for Raspberry Pi
+    resources:
+      limits:
+        cpu: 250m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+    # Ingress for Dex
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+      hosts:
+        - host: dex.eldertree.local
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: dex-tls
+          hosts:
+            - dex.eldertree.local

--- a/clusters/eldertree/observability/dex-helmrepository.yaml
+++ b/clusters/eldertree/observability/dex-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dex
+  namespace: observability
+spec:
+  interval: 24h
+  url: https://charts.dexidp.io

--- a/clusters/eldertree/observability/dex-rbac.yaml
+++ b/clusters/eldertree/observability/dex-rbac.yaml
@@ -1,0 +1,16 @@
+# ClusterRoleBinding: Grant GitHub org members full Weave GitOps access
+# Dex maps GitHub org membership to groups like "raolivei:*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-ui-github-admin
+subjects:
+  # Match any member of the raolivei GitHub org
+  - kind: Group
+    name: "raolivei"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/clusters/eldertree/observability/kustomization.yaml
+++ b/clusters/eldertree/observability/kustomization.yaml
@@ -10,6 +10,10 @@ resources:
   - vault-scrape-config.yaml # Vault telemetry scrape configuration
   - flux-ui-externalsecret.yaml # Flux UI admin password from Vault
   - flux-ui-helmrelease.yaml # Flux UI (Weave GitOps) for managing FluxCD resources
+  - dex-helmrepository.yaml # Dex Helm chart repo (charts.dexidp.io)
+  - dex-externalsecret.yaml # GitHub OAuth client credentials from Vault
+  - dex-helmrelease.yaml # Dex OIDC provider for Flux UI GitHub login
+  - dex-rbac.yaml # ClusterRoleBinding for GitHub org members
   - postgres-exporter.yaml # PostgreSQL metrics exporter for all DB instances
   - redis-exporter.yaml # Redis metrics exporter for all Redis instances
   # grafana-dashboards-configmap.yaml removed - Longhorn no longer in use

--- a/clusters/eldertree/openclaw/skills-configmap.yaml
+++ b/clusters/eldertree/openclaw/skills-configmap.yaml
@@ -129,13 +129,13 @@ data:
     ```bash
     # Get recent events across all namespaces (warnings and errors)
     kubectl get events -A --sort-by='.lastTimestamp' | grep -E "Warning|Error" | tail -30
-    
+
     # Get events for a specific namespace
     kubectl get events -n swimto --sort-by='.lastTimestamp'
-    
+
     # Check for pod restarts (indicates issues)
     kubectl get pods -A | grep -E "CrashLoopBackOff|Error|Pending|ImagePullBackOff"
-    
+
     # Check node status
     kubectl get nodes
     kubectl describe nodes | grep -A 5 "Conditions:"


### PR DESCRIPTION
## Summary

- **Dex OIDC provider**: Adds GitHub OAuth authentication for the Flux UI (Weave GitOps). Deploys Dex via its official Helm chart with credentials synced from Vault via ExternalSecret. Access restricted to `raolivei` GitHub org members with `cluster-admin` RBAC.
- **CoreDNS custom config**: Resolves `*.eldertree.local` hostnames inside the cluster (required for pods to reach Dex, Grafana, Flux UI, etc. by their ingress names).
- Minor whitespace fixes in `SERVICES_REFERENCE.md` and `skills-configmap.yaml`.

## New resources

| File | Type | Purpose |
|------|------|---------|
| `core-infrastructure/coredns-custom.yaml` | ConfigMap | Maps `*.eldertree.local` → Traefik VIP (192.168.2.200) |
| `observability/dex-helmrepository.yaml` | HelmRepository | charts.dexidp.io |
| `observability/dex-externalsecret.yaml` | ExternalSecret | GitHub OAuth creds from Vault |
| `observability/dex-helmrelease.yaml` | HelmRelease | Dex v2.41.1 with ingress |
| `observability/dex-rbac.yaml` | ClusterRoleBinding | GitHub org → cluster-admin |

## Prerequisites

- Vault path `secret/dex/github-oauth` must contain `client-id` and `client-secret`
- GitHub OAuth App configured with redirect URI `https://dex.eldertree.local/callback`

## Test plan

- [x] Verify CoreDNS picks up the custom config (`kubectl get cm coredns-custom -n kube-system`)
- [x] Verify Dex pod starts and is healthy
- [x] Test `https://dex.eldertree.local/.well-known/openid-configuration` returns discovery doc
- [x] Test Flux UI redirects to GitHub login via Dex

Made with [Cursor](https://cursor.com)