### PR TITLE
feat: CA ClusterIssuer + HTTPS for Dex OIDC + migrate all services

### DIFF
--- a/clusters/eldertree/eldertree-docs/audio-ingress.yaml
+++ b/clusters/eldertree/eldertree-docs/audio-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: eldertree-docs
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: ca-cluster-issuer
     external-dns.alpha.kubernetes.io/hostname: audio.eldertree.local
   labels:
     app.kubernetes.io/name: eldertree-docs

--- a/clusters/eldertree/eldertree-docs/ingress.yaml
+++ b/clusters/eldertree/eldertree-docs/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: eldertree-docs
     app.kubernetes.io/component: documentation
   annotations:
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: ca-cluster-issuer
 spec:
   ingressClassName: traefik
   tls:

--- a/clusters/eldertree/observability/ca-bundle-configmap.yaml
+++ b/clusters/eldertree/observability/ca-bundle-configmap.yaml
@@ -1,0 +1,43 @@
+# ConfigMap containing the Eldertree Local CA certificate (PEM)
+# Mount into pods that need to verify certificates signed by ca-cluster-issuer
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eldertree-ca-bundle
+  namespace: observability
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIF+DCCA+CgAwIBAgIUVDSsJhh8xuAhfUeHF/oao2gkfqMwDQYJKoZIhvcNAQEL
+    BQAwTTEbMBkGA1UEAwwSRWxkZXJ0cmVlIExvY2FsIENBMRIwEAYDVQQKDAlFbGRl
+    cnRyZWUxGjAYBgNVBAsMEUxvY2FsIERldmVsb3BtZW50MB4XDTI1MTIzMDAzNTM0
+    OVoXDTM1MTIyODAzNTM0OVowTTEbMBkGA1UEAwwSRWxkZXJ0cmVlIExvY2FsIENB
+    MRIwEAYDVQQKDAlFbGRlcnRyZWUxGjAYBgNVBAsMEUxvY2FsIERldmVsb3BtZW50
+    MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA4F6LzTW768fruCAS5lYC
+    +5Pvc5daS84FWd6lLIKQzqPmkzXutWxoAJgAujv800ho8B3KYhRrBQlPJR8n0jYO
+    Xy3SMiDyfNPEfhgukg6+bEz7W3i9YiRkpIAEFRiysDfn1KmesU9ENLmCSMwzKE/m
+    GJNO9pcyxBEaf0W/sgUWhvSygnN4+6xILkQtYoXIQS5QSwxwDRTQYrqk9xbJ4y89
+    5eGzXNfMo/kVUxrdID5/EA6Ggm0w1CDjzMmGbtOmeKazOcxbXazTVR2F5HEh8Gq6
+    vo6APb0HvUJrKKczZAEGIBYd4YyxrACAVSF0WE7qimimqPqpuETkWqQni54oVS0f
+    idcTYIDyrbiuLqj5Gny5ZcoNrMgzv7K7XrmF0mcRYlfvyDERhAws+fz5RL6btPAc
+    vL9wkT2b+XEd1VL/DOXghp5xt4tsqHBamOCUkD6D5HWnkP5X5kLu9PI5NZaFd5/y
+    H+5Xmsz+XXTlqB6ngMifh3bJhml5CynAJunbTmELLv3Hw40jfDwLJbkb8hwGjhyi
+    MhNj+vsoPiicRU7fUFWgBeLCeG5+bHrXKGY6amB9BNOoYCkuklRbOlJ2DF5B1tOZ
+    ddKcW02pZ7mzODL7mPqaSRjrNOWLfK558P/Cz/as0idSa34xw1OW4uEzkhV3KDWc
+    /eebgAfkoyMsk388AknfnyMCAwEAAaOBzzCBzDAPBgNVHRMBAf8EBTADAQH/MA4G
+    A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQU2uM4X2ryNXfareB7/9ynkFwYUjQwgYkG
+    A1UdIwSBgTB/gBTa4zhfavI1d9qt4Hv/3KeQXBhSNKFRpE8wTTEbMBkGA1UEAwwS
+    RWxkZXJ0cmVlIExvY2FsIENBMRIwEAYDVQQKDAlFbGRlcnRyZWUxGjAYBgNVBAsM
+    EUxvY2FsIERldmVsb3BtZW50ghRUNKwmGHzG4CF9R4cX+hqjaCR+ozANBgkqhkiG
+    9w0BAQsFAAOCAgEARJRrsVWbOKVUdVAtvWvrmj+QL3vEpFYoZTNZVl/pyrB3Hik4
+    u34U/7NPDPkgT8qtSc3ELSZgQVccofy2GsjcHdKYJWmTHyhGwNwN+AMp3a14EaSD
+    mGVjwfmDyZCfHHsFybYt/lx98cRWYvsq4JUAX4lxX0/OM0rjqjSdokUWMi7lSiZq
+    Juiu90lR8pw2tq/2ngdI3Nitl5ezTuPriVWQH+VL4SjMva+dDjQbYqX5DFRKDWf7
+    CDA2AKNli1/j6faV6G5iDH0FMKWV6Z61oHDkYtRxdHWS5tWPsQJwQKNyi8stYESh
+    3EH+eau1NMerPhTEbAygzUw2zRf3cDglX6j+hBTaaBQb29F0ih5QMvI798kvLR4J
+    z4KqGefBZGIaFT+X041Vvli6Zc2BcvwshTE4LBLVWCfZ2ByAiye1NiZclk+PfNQA
+    SwfBNf2XfWATs3WS3b1DYKno4lkpdpwsq1kPHi4bU3Sx7cccdiKXOTPlTmcJ6iP+
+    AQr4prXrvGP6CnHynvHwR0DI6hB8O5ymit1To0iM61hyIztVJ1UZEazx4VNqhi9w
+    nrt4cPibtYVi4SBS2uf6cuNmCaNXFbOASkwYYyTCW2tqg7pSjDI3oi1RPHFEqIPm
+    cfu0S4SLF830qqXBooZCOhhtgokdYZvtwQQAANstyw6je0ipF3o900JrspU=
+    -----END CERTIFICATE-----

--- a/clusters/eldertree/observability/dex-helmrelease.yaml
+++ b/clusters/eldertree/observability/dex-helmrelease.yaml
@@ -36,8 +36,8 @@ spec:
             key: client-secret
 
     config:
-      # HTTP for issuer - avoids self-signed TLS issues for in-cluster OIDC discovery
-      issuer: http://dex.eldertree.local
+      # HTTPS issuer - CA-signed certificate trusted by pods mounting the CA bundle
+      issuer: https://dex.eldertree.local
 
       storage:
         type: memory
@@ -58,10 +58,9 @@ spec:
           config:
             clientID: $GITHUB_CLIENT_ID
             clientSecret: $GITHUB_CLIENT_SECRET
-            redirectURI: http://dex.eldertree.local/callback
-            # Restrict to your GitHub user
-            orgs:
-              - name: raolivei
+            redirectURI: https://dex.eldertree.local/callback
+            loadAllGroups: true
+            # No orgs filter -- raolivei is a personal account, not an organization
 
     # Resource limits for Raspberry Pi
     resources:
@@ -72,12 +71,18 @@ spec:
         cpu: 50m
         memory: 64Mi
 
-    # Ingress for Dex (HTTP only - internal homelab service)
+    # Ingress for Dex with TLS signed by the Eldertree Local CA
     ingress:
       enabled: true
       className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: ca-cluster-issuer
       hosts:
         - host: dex.eldertree.local
           paths:
             - path: /
               pathType: Prefix
+      tls:
+        - secretName: dex-tls
+          hosts:
+            - dex.eldertree.local

--- a/clusters/eldertree/observability/dex-rbac.yaml
+++ b/clusters/eldertree/observability/dex-rbac.yaml
@@ -1,13 +1,13 @@
-# ClusterRoleBinding: Grant GitHub org members full Weave GitOps access
-# Dex maps GitHub org membership to groups like "raolivei:*"
+# ClusterRoleBinding: Grant GitHub user full Weave GitOps access via OIDC
+# Dex authenticates via GitHub OAuth -- raolivei is a personal account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flux-ui-github-admin
 subjects:
-  # Match any member of the raolivei GitHub org
-  - kind: Group
+  # Match the GitHub username authenticated via Dex OIDC
+  - kind: User
     name: "raolivei"
     apiGroup: rbac.authorization.k8s.io
 roleRef:

--- a/clusters/eldertree/observability/flux-ui-helmrelease.yaml
+++ b/clusters/eldertree/observability/flux-ui-helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
     # Global configuration
     global:
       domain: eldertree.local
-      clusterIssuer: selfsigned-cluster-issuer
+      clusterIssuer: ca-cluster-issuer
 
     # Weave GitOps configuration
     # Values passed to weave-gitops dependency (gitops-server chart)
@@ -64,7 +64,7 @@ spec:
             hosts:
               - flux.eldertree.local
         annotations:
-          cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+          cert-manager.io/cluster-issuer: ca-cluster-issuer
       
       # Resource limits for Raspberry Pi
       resources:
@@ -103,8 +103,19 @@ spec:
       # OIDC via Dex - enables "Login with OIDC Provider" button
       oidcSecret:
         create: true
-        issuerURL: http://dex.eldertree.local
+        issuerURL: https://dex.eldertree.local
         clientID: weave-gitops
         clientSecret: weave-gitops-dex-secret
         redirectURL: https://flux.eldertree.local/oauth2/callback
         cookieDuration: "24h"
+
+      # Mount Eldertree CA bundle so the OIDC client trusts Dex's CA-signed TLS cert
+      extraVolumes:
+        - name: ca-bundle
+          configMap:
+            name: eldertree-ca-bundle
+      extraVolumeMounts:
+        - name: ca-bundle
+          mountPath: /etc/ssl/certs/eldertree-ca.crt
+          subPath: ca.crt
+          readOnly: true

--- a/clusters/eldertree/observability/kustomization.yaml
+++ b/clusters/eldertree/observability/kustomization.yaml
@@ -13,7 +13,8 @@ resources:
   - dex-helmrepository.yaml # Dex Helm chart repo (charts.dexidp.io)
   - dex-externalsecret.yaml # GitHub OAuth client credentials from Vault
   - dex-helmrelease.yaml # Dex OIDC provider for Flux UI GitHub login
-  - dex-rbac.yaml # ClusterRoleBinding for GitHub org members
+  - dex-rbac.yaml # ClusterRoleBinding for GitHub user via OIDC
+  - ca-bundle-configmap.yaml # Eldertree CA cert for pods verifying CA-signed TLS
   - postgres-exporter.yaml # PostgreSQL metrics exporter for all DB instances
   - redis-exporter.yaml # Redis metrics exporter for all Redis instances
   # grafana-dashboards-configmap.yaml removed - Longhorn no longer in use

--- a/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
+++ b/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
               hosts:
                 - pushgateway.eldertree.local
           annotations:
-            cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+            cert-manager.io/cluster-issuer: ca-cluster-issuer
       server:
         # Reduce retention to 7 days (was 15d) to save disk space on node-3
         retention: "7d"
@@ -52,7 +52,7 @@ spec:
               hosts:
                 - prometheus.eldertree.local
           annotations:
-            cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+            cert-manager.io/cluster-issuer: ca-cluster-issuer
         # Additional scrape configs for services
         additionalScrapeConfigs:
           - key: pihole-scrape.yaml
@@ -78,5 +78,5 @@ spec:
             hosts:
               - grafana.eldertree.local
         annotations:
-          cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+          cert-manager.io/cluster-issuer: ca-cluster-issuer
 

--- a/clusters/eldertree/observability/pushgateway-ingress.yaml
+++ b/clusters/eldertree/observability/pushgateway-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pushgateway
   namespace: observability
   annotations:
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: ca-cluster-issuer
 spec:
   ingressClassName: traefik
   rules:

--- a/helm/cert-manager-issuers/templates/ca-issuer.yaml
+++ b/helm/cert-manager-issuers/templates/ca-issuer.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ca.enabled }}
+---
+# Secret containing the CA certificate and private key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.ca.secretName }}
+  namespace: cert-manager
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.ca.certificate }}
+  tls.key: {{ .Values.ca.privateKey }}
+---
+# ClusterIssuer using the CA key pair to sign certificates
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.ca.name }}
+spec:
+  ca:
+    secretName: {{ .Values.ca.secretName }}
+{{- end }}

--- a/helm/eldertree-app/templates/ingress.yaml
+++ b/helm/eldertree-app/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     {{- if and $ing.tls $ing.tls.certManager }}
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: {{ $.Values.global.clusterIssuer | default "ca-cluster-issuer" }}
     {{- end }}
     {{- if $ing.middlewares }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $ing.middlewares }}

--- a/helm/eldertree-app/values.yaml
+++ b/helm/eldertree-app/values.yaml
@@ -28,6 +28,9 @@ global:
       drop:
         - ALL
 
+  # -- Default cert-manager ClusterIssuer for TLS ingresses
+  clusterIssuer: ca-cluster-issuer
+
   # -- Default node selector (ARM64 cluster)
   nodeSelector:
     kubernetes.io/arch: arm64

--- a/helm/flux-ui/values.yaml
+++ b/helm/flux-ui/values.yaml
@@ -4,7 +4,7 @@
 # Global configuration
 global:
   domain: eldertree.local
-  clusterIssuer: selfsigned-cluster-issuer
+  clusterIssuer: ca-cluster-issuer
 
 # Weave GitOps configuration
 # Values passed directly to weave-gitops dependency (gitops-server chart)
@@ -31,7 +31,7 @@ weave-gitops:
         hosts:
           - flux.eldertree.local
     annotations:
-      cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+      cert-manager.io/cluster-issuer: ca-cluster-issuer
   
   # Resource limits for Raspberry Pi
   resources:

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -3,7 +3,7 @@
 # Global configuration
 global:
   domain: eldertree.local
-  clusterIssuer: selfsigned-cluster-issuer
+  clusterIssuer: ca-cluster-issuer
 
 # Prometheus configuration
 # Note: External services (Vault, Pi-hole, Visage) are scraped via kubernetes-service-endpoints
@@ -29,7 +29,7 @@ prometheus:
           hosts:
             - alertmanager.eldertree.local
       annotations:
-        cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+        cert-manager.io/cluster-issuer: ca-cluster-issuer
   nodeExporter:
     enabled: true
   pushgateway:
@@ -46,7 +46,7 @@ prometheus:
           hosts:
             - pushgateway.eldertree.local
       annotations:
-        cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+        cert-manager.io/cluster-issuer: ca-cluster-issuer
   kube-state-metrics:
     enabled: true
     fullnameOverride: "monitoring-stack-kube-state-metrics"
@@ -68,7 +68,7 @@ prometheus:
           hosts:
             - prometheus.eldertree.local
       annotations:
-        cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+        cert-manager.io/cluster-issuer: ca-cluster-issuer
     global:
       scrape_interval: 30s
       scrape_timeout: 10s
@@ -376,4 +376,4 @@ grafana:
         hosts:
           - grafana.eldertree.local
     annotations:
-      cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+      cert-manager.io/cluster-issuer: ca-cluster-issuer

--- a/helm/pi-hole/templates/ingress.yaml
+++ b/helm/pi-hole/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: ca-cluster-issuer
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
## Summary

- **CA ClusterIssuer**: Add missing `ca-issuer.yaml` template to cert-manager-issuers chart, creating the `ca-key-pair` Secret and `ca-cluster-issuer` ClusterIssuer from the existing CA cert/key in HelmRelease values
- **Fix Dex GitHub auth**: Remove `orgs` filter (raolivei is a personal account, not an org) and update RBAC to `User` kind — fixes `user "raolivei" not in required orgs or teams`
- **Dex HTTPS**: Migrate Dex back to HTTPS with CA-signed TLS certificate, mount CA bundle ConfigMap in Flux UI pod so OIDC discovery trusts the cert
- **Migrate all services**: Switch all `*.eldertree.local` ingresses from `selfsigned-cluster-issuer` to `ca-cluster-issuer` (Grafana, Prometheus, Pushgateway, Flux UI, eldertree-docs, audio, Pi-hole)
- **Shared chart**: Make `clusterIssuer` configurable via `global.clusterIssuer` in eldertree-app chart

## Files changed

| Area | Files |
|------|-------|
| CA issuer template | `helm/cert-manager-issuers/templates/ca-issuer.yaml` (new) |
| CA bundle | `clusters/eldertree/observability/ca-bundle-configmap.yaml` (new) |
| Dex OIDC | `dex-helmrelease.yaml`, `dex-rbac.yaml` |
| Flux UI | `flux-ui-helmrelease.yaml` |
| Observability | `monitoring-stack-helmrelease.yaml`, `pushgateway-ingress.yaml`, `kustomization.yaml` |
| Docs | `eldertree-docs/ingress.yaml`, `audio-ingress.yaml` |
| Helm charts | `eldertree-app`, `flux-ui`, `monitoring-stack`, `pi-hole` defaults |

## Manual steps after merge

1. Update GitHub OAuth app callback URL to `https://dex.eldertree.local/callback`
2. Verify `ca-cluster-issuer` is Ready: `kubectl get clusterissuer ca-cluster-issuer`
3. Verify Dex TLS cert: `curl -k https://dex.eldertree.local/.well-known/openid-configuration`
4. Test OIDC login via Flux UI


Made with [Cursor](https://cursor.com)