### PR TITLE
fix(pihole): make ephemeral for DNS HA

### DIFF
--- a/clusters/eldertree/dns-services/pihole/helmrelease.yaml
+++ b/clusters/eldertree/dns-services/pihole/helmrelease.yaml
@@ -23,12 +23,12 @@ spec:
       retries: 3
     timeout: 15m
   values:
+    persistence:
+      enabled: false
+    strategy: RollingUpdate
     service:
       type: LoadBalancer
-      # NOTE: Explicitly set loadBalancerClass to null to remove it from previous releases
-      # kube-vip v0.8.3 ignores services with this field set
       loadBalancerClass: null
-      # Explicit IP so kube-vip assigns 192.168.2.201 (router DNS)
       loadBalancerIP: 192.168.2.201
     config:
       clusterIP: 192.168.2.201

--- a/helm/pi-hole/templates/deployment.yaml
+++ b/helm/pi-hole/templates/deployment.yaml
@@ -103,22 +103,24 @@ spec:
               mountPath: /etc/dnsmasq.d/99-upstream-dns.conf
               subPath: 99-upstream-dns.conf
               readOnly: true
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10 && pihole -g &"]
           resources:
             {{- toYaml .Values.resources.pihole | nindent 12 }}
           livenessProbe:
-            # Use /admin/ endpoint which returns 302 (redirect) instead of 403
-            # The root / path returns 403 Forbidden, causing liveness probe failures
             httpGet:
               path: /admin/
               port: 80
-            initialDelaySeconds: 60
+            initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: 53
-            initialDelaySeconds: 60
+            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
@@ -191,8 +193,12 @@ spec:
             failureThreshold: 3
       volumes:
         - name: pihole-data
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "pi-hole.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: dnsmasq-config
           configMap:
             name: {{ include "pi-hole.fullname" . }}-dnsmasq

--- a/helm/pi-hole/templates/pvc.yaml
+++ b/helm/pi-hole/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,12 +12,4 @@ spec:
     requests:
       storage: {{ .Values.persistence.size }}
   storageClassName: {{ .Values.persistence.storageClass }}
-
-
-
-
-
-
-
-
-
+{{- end }}

--- a/helm/pi-hole/values.yaml
+++ b/helm/pi-hole/values.yaml
@@ -37,21 +37,12 @@ service:
   httpsNodePort: 30443
 
 persistence:
-  enabled: true
+  enabled: false
   size: 2Gi
   storageClass: local-path
-  # For HA, each replica needs its own PVC
-  # Consider using ReadWriteMany storage class for shared storage
-  # Or disable persistence for stateless operation (not recommended)
 
-# High Availability Configuration
-# NOTE: Pi-hole with persistence (ReadWriteOnce) cannot be shared between replicas
-# For true HA, you need either:
-# 1. Disable persistence (lose config on restart) - set persistence.enabled: false
-# 2. Use shared storage (NFS, etc.) with ReadWriteMany access mode
-# 3. Keep single replica but ensure pod disruption budget and health checks
-replicas: 1 # Set to 2+ for HA (requires shared storage)
-strategy: Recreate # Set to RollingUpdate for HA (requires shared storage)
+replicas: 1
+strategy: RollingUpdate
 
 config:
   timezone: UTC


### PR DESCRIPTION
## Summary

- Remove PVC dependency so Pi-hole can reschedule on any node when a node goes down
- Switch to `emptyDir` volume — gravity DB rebuilds via postStart hook, FTL telemetry is non-critical, all DNS config injected via ConfigMaps
- Switch strategy to `RollingUpdate` (safe without shared volume)
- Reduce probe delays for faster recovery

## Problem

Pi-hole's `local-path` PVC pins it to node-1 via PV node affinity. When node-1 goes down, Pi-hole can't reschedule anywhere else, breaking DNS for the entire network. ExternalDNS crashes (can't reach BIND), new ingress hostnames never resolve.

## Recovery After This Change

| Scenario | Recovery Time |
|----------|--------------|
| Node dies | ~30-60s (K8s reschedules, BIND rebuilds zone, ExternalDNS re-syncs) |
| Pod crashes | ~15-30s (restarts on same node) |

## Test plan

- [ ] FluxCD reconciles successfully
- [ ] Pi-hole pod runs without PVC (`kubectl get pvc -n pihole` returns empty)
- [ ] DNS resolution works: `dig google.com @192.168.2.201`
- [ ] `.local` resolution works: `dig ollie.eldertree.local @192.168.2.201`
- [ ] Ad-blocking works after gravity rebuild (~60s)
- [ ] Simulate failure: cordon node, delete pod, verify reschedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)