### PR TITLE
infra(openclaw): add Gmail skill and Vault secret configuration

### DIFF
--- a/clusters/eldertree/openclaw/externalsecret.yaml
+++ b/clusters/eldertree/openclaw/externalsecret.yaml
@@ -37,3 +37,20 @@ spec:
       remoteRef:
         key: secret/openclaw/openrouter
         property: api-key
+    # Gmail OAuth Credentials
+    - secretKey: ELDER_GMAIL_CLIENT_ID
+      remoteRef:
+        key: secret/openclaw/gmail
+        property: client-id
+    - secretKey: ELDER_GMAIL_CLIENT_SECRET
+      remoteRef:
+        key: secret/openclaw/gmail
+        property: client-secret
+    - secretKey: ELDER_GMAIL_REFRESH_TOKEN
+      remoteRef:
+        key: secret/openclaw/gmail
+        property: refresh-token
+    - secretKey: ELDER_GMAIL_USER_EMAIL
+      remoteRef:
+        key: secret/openclaw/gmail
+        property: user-email

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -187,6 +187,30 @@ spec:
                 name: elder-secrets
                 key: GROQ_API_KEY
                 optional: true
+          - name: ELDER_GMAIL_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: ELDER_GMAIL_CLIENT_ID
+                optional: true
+          - name: ELDER_GMAIL_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: ELDER_GMAIL_CLIENT_SECRET
+                optional: true
+          - name: ELDER_GMAIL_REFRESH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: ELDER_GMAIL_REFRESH_TOKEN
+                optional: true
+          - name: ELDER_GMAIL_USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: ELDER_GMAIL_USER_EMAIL
+                optional: true
         resources:
           requests: { cpu: "250m", memory: "256Mi" }
           limits: { cpu: "500m", memory: "512Mi" }

--- a/clusters/eldertree/openclaw/skills-configmap.yaml
+++ b/clusters/eldertree/openclaw/skills-configmap.yaml
@@ -425,3 +425,95 @@ data:
 
     User: "What pods are failing?"
     Assistant: *calls elder_cluster_health, checks for failed pods and warnings*
+
+  # Gmail Skill - Read and send emails
+  gmail-skill.md: |
+    # Gmail Skill
+
+    Read, search, and manage Gmail inbox for rafa.oliveira1@gmail.com.
+
+    ## Tools
+
+    ### gmail_list
+    Search and list emails from inbox.
+
+    Parameters:
+    - query: string - Gmail search query (e.g., "is:unread", "from:someone@example.com", "subject:invoice")
+    - max_results: number (optional) - Max messages to return (default: 20)
+
+    Example: "Show my unread emails"
+
+    ### gmail_get
+    Get full email content including body and headers.
+
+    Parameters:
+    - message_id: string - Gmail message ID
+
+    Example: "Show me the full content of message ID xyz123"
+
+    ### gmail_send
+    Send an email (requires approval).
+
+    Parameters:
+    - to: string - Recipient email address
+    - subject: string - Email subject
+    - body: string - Email body content
+    - html: boolean (optional) - Is body HTML formatted? (default: false)
+    - cc: string (optional) - CC recipients (comma-separated)
+    - bcc: string (optional) - BCC recipients (comma-separated)
+
+    Example: "Send email to test@example.com with subject 'Test' and body 'Hello'"
+
+    ### gmail_modify
+    Archive, mark read/unread, or apply labels to emails.
+
+    Parameters:
+    - message_id: string - Gmail message ID
+    - add_labels: array (optional) - Label IDs to add (e.g., ["IMPORTANT"])
+    - remove_labels: array (optional) - Label IDs to remove (e.g., ["UNREAD"])
+
+    Example: "Archive this email"
+
+    ### gmail_thread
+    Get full conversation thread.
+
+    Parameters:
+    - thread_id: string - Gmail thread ID
+
+    Example: "Show me the full thread of conversation xyz"
+
+    ## Implementation
+
+    Elder API endpoints (require X-API-Key header):
+    - POST /api/gmail/list - List/search messages
+    - POST /api/gmail/get - Get single message
+    - POST /api/gmail/send - Send email (approval required)
+    - POST /api/gmail/modify - Modify labels
+    - POST /api/gmail/thread - Get conversation thread
+
+    Elder service URL: http://elder.openclaw.svc.cluster.local:8000
+
+    Authentication: Elder handles OAuth refresh token from Vault (secret/openclaw/gmail).
+
+    ## Common Label IDs
+
+    - UNREAD - Unread messages
+    - STARRED - Starred messages
+    - IMPORTANT - Important messages
+    - SENT - Sent messages
+    - DRAFT - Draft messages
+    - ARCHIVE - Archived messages
+
+    ## Example Conversations
+
+    User: "Show me my unread emails"
+    Assistant: *calls gmail_list with query="is:unread"*
+
+    User: "Find emails from alice@example.com"
+    Assistant: *calls gmail_list with query="from:alice@example.com"*
+
+    User: "Send an email to bob@example.com"
+    Assistant: *calls gmail_send with to="bob@example.com" → approval required → shows plan → asks for confirmation*
+
+    User: "Archive all spam"
+    Assistant: *calls gmail_list with query="label:SPAM" → for each message calls gmail_modify with add_labels=["ARCHIVE"]*


### PR DESCRIPTION
## Summary

- Add `gmail-skill.md` to openclaw skills ConfigMap so openclaw can list, read, send, and manage Gmail
- Update `externalsecret.yaml` to sync Gmail OAuth credentials from Vault to Elder pod environment

## Changes

- `clusters/eldertree/openclaw/skills-configmap.yaml` — gmail-skill with 5 tools (list, get, send, modify, thread)
- `clusters/eldertree/openclaw/externalsecret.yaml` — 4 new keys synced from `secret/openclaw/gmail`

## Deployment notes

ExternalSecret and ConfigMap already applied manually to the cluster.
Elder pod pending due to pre-existing node-1 outage (PVC affinity issue — tracked separately).

## Test plan

- [ ] Vault secret at `secret/openclaw/gmail` verified
- [ ] K8s secret `openclaw-secrets` contains `ELDER_GMAIL_*` keys ✅
- [ ] Skills ConfigMap contains `gmail-skill.md` ✅
- [ ] Elder pod running and Gmail endpoints reachable
- [ ] End-to-end test via Telegram/Web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)