### PR TITLE
chore(personal-website): update image to v0.2.2

### DIFF
--- a/clusters/eldertree/personal-website/helmrelease.yaml
+++ b/clusters/eldertree/personal-website/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
       personal-website:
         image:
           repository: ghcr.io/raolivei/personal-website
-          tag: v0.2.1 # {"$imagepolicy": "personal-website:personal-website-policy:tag"}
+          tag: v0.2.2 # {"$imagepolicy": "personal-website:personal-website-policy:tag"}
           pullPolicy: IfNotPresent
         port: 80
         podSecurityContext:


### PR DESCRIPTION
## Summary
Update personal-website image from v0.2.1 → v0.2.2

## Changes
- Identity alignment release
- Platform engineer positioning
- Kubernetes/distributed systems focus  
- Publications section added
- Refined skills taxonomy

## Image
- `ghcr.io/raolivei/personal-website:v0.2.2`
- Built from: https://github.com/raolivei/personal-website/actions/runs/26423428540

## Notes
Manual update because FluxCD ImageUpdateAutomation has git auth issues (will investigate separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)