### PR TITLE
infra(security): harden openclaw and elder RBAC and network policies

### DIFF
--- a/clusters/eldertree/openclaw/elder-rbac.yaml
+++ b/clusters/eldertree/openclaw/elder-rbac.yaml
@@ -10,11 +10,12 @@ kind: ClusterRole
 metadata:
   name: elder-agent
 rules:
+  # Read-only cluster resources (no secrets)
   - apiGroups: [""]
     resources: ["pods", "pods/log"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["services", "configmaps", "secrets", "namespaces"]
+    resources: ["services", "configmaps", "namespaces"]
     verbs: ["get", "list"]
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
@@ -38,6 +39,17 @@ rules:
     resources: ["gitrepositories"]
     verbs: ["get", "list", "patch"]
 ---
+# Namespace-scoped role for secrets (openclaw namespace only)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: elder-secrets-reader
+  namespace: openclaw
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -49,4 +61,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: elder-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+# Bind secrets access only to openclaw namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: elder-secrets-reader-binding
+  namespace: openclaw
+subjects:
+  - kind: ServiceAccount
+    name: elder
+    namespace: openclaw
+roleRef:
+  kind: Role
+  name: elder-secrets-reader
   apiGroup: rbac.authorization.k8s.io

--- a/clusters/eldertree/openclaw/networkpolicy.yaml
+++ b/clusters/eldertree/openclaw/networkpolicy.yaml
@@ -1,0 +1,71 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-elder-isolation
+  namespace: openclaw
+  labels:
+    app: openclaw
+spec:
+  # Restrict ingress to Elder pod
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: elder
+  ingress:
+    # Allow from OpenClaw pod (same namespace)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: openclaw
+      ports:
+        - protocol: TCP
+          port: 8000
+    # Allow from Traefik ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: traefik
+      ports:
+        - protocol: TCP
+          port: 8000
+    # Allow health checks from kube-system (kubelet liveness probes)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: kube-system
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-ingress-only
+  namespace: openclaw
+  labels:
+    app: openclaw
+spec:
+  # Restrict ingress to OpenClaw pod
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: openclaw
+  ingress:
+    # Allow from Traefik ingress controller only
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: traefik
+      ports:
+        - protocol: TCP
+          port: 18789
+    # Allow health checks from kube-system
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: kube-system
+      ports:
+        - protocol: TCP
+          port: 18789

--- a/clusters/eldertree/openclaw/rbac.yaml
+++ b/clusters/eldertree/openclaw/rbac.yaml
@@ -99,17 +99,13 @@ rules:
       - limitranges
       - resourcequotas
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Read-only pod introspection (no exec, eviction, or portforward for security)
   - apiGroups: [""]
     resources:
       - pods/log
-      - pods/exec
-      - pods/portforward
       - pods/proxy
       - services/proxy
-    verbs: ["get", "create"]
-  - apiGroups: [""]
-    resources: ["pods/eviction"]
-    verbs: ["create"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "patch", "update"]


### PR DESCRIPTION
## Summary

Security hardening for OpenClaw + Elder Gmail API integration.

### Changes
- **NetworkPolicy** — Isolate Elder and OpenClaw pods
  - Elder: allow only from openclaw pod + traefik
  - OpenClaw: allow only from traefik
  
- **Elder RBAC scoped** — Remove cluster-wide secrets read
  - Elder can only read secrets in `openclaw` namespace
  - Prevents access to vault tokens, other app credentials
  
- **OpenClaw RBAC hardened** — Remove dangerous verbs
  - Remove: `pods/exec`, `pods/eviction`, `pods/portforward`
  - Prevents LLM prompt injection from executing arbitrary commands

### Verification
- ✅ Elder cannot read secrets outside openclaw
- ✅ OpenClaw cannot exec into pods
- ✅ NetworkPolicies enforce isolation

### Follow-up
See issue #169 for Phase 2:
- Traefik IP allowlist middleware
- Shell exec policy command blocklists

🤖 Generated with [Claude Code](https://claude.com/claude-code)