### PR TITLE
fix: harden hardware watchdog on all eldertree nodes

### DIFF
--- a/.claude/agents/eldertree-cluster-ops-handoff.md
+++ b/.claude/agents/eldertree-cluster-ops-handoff.md
@@ -1,0 +1,51 @@
+---
+name: eldertree-cluster-ops-handoff
+description: Continuity agent for eldertree K3s cluster ops, watchdog incidents, and pi-fleet GitOps.
+---
+
+# Eldertree cluster ops handoff
+
+## SSH / networking
+
+| Node | WiFi (laptop) | Gigabit (in-cluster) |
+|------|---------------|----------------------|
+| node-1 | `192.168.2.101` | `10.0.0.1` |
+| node-2 | `192.168.2.102` | `10.0.0.2` |
+| node-3 | `192.168.2.103` | `10.0.0.3` |
+
+- Key: `~/.ssh/id_ed25519_raolivei`, user `raolivei`
+- Kubeconfig: `KUBECONFIG=~/.kube/config-eldertree` (VIP `192.168.2.100:6443`)
+
+## Watchdog checklist (after any hang)
+
+```bash
+./pi-fleet/scripts/verify-watchdog.sh
+```
+
+Must show: RPI drop-in **absent**, `watchdog` holds `/dev/watchdog`, `alive=/dev/watchdog` in journal.
+
+Ansible (all nodes):
+
+```bash
+cd pi-fleet/ansible
+ansible-playbook -i inventory/hosts.yml playbooks/setup-hardware-watchdog.yml
+```
+
+Forensics: `journalctl --boot=-1` (requires persistent journal — enabled by playbook).
+
+## Known incident docs
+
+- `pi-fleet/docs/NODE-1-HANG-ROOT-CAUSE-2026-05-26.md` — systemd `40-rpi-enable-watchdog.conf`
+- `pi-fleet/docs/NODE-1-HANG-2026-05-26-SECOND.md` — second hang, test-binary gap
+- `pi-fleet/docs/HARDWARE_WATCHDOG.md` — runbook
+
+## Open / out of scope unless asked
+
+- README PR branches (canopy, swimTO, workspace-config)
+- Cloudflare tunnel HTTP 1033 on public sites
+- swimto Postgres `local-path` scheduling
+
+## Flux
+
+- App changes: `pi-fleet/clusters/eldertree/`
+- Reconcile: `flux reconcile kustomization flux-system --with-source`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hardware watchdog (all nodes)** — Disable Raspberry Pi OS `40-rpi-enable-watchdog.conf` and set `RuntimeWatchdogSec=0` so the watchdog daemon holds `/dev/watchdog`. Add `watchdog-k3s-health.sh` test-binary (k3s, kubelet healthz, API :6443), peer-only ping targets, persistent journald, improved `scripts/verify-watchdog.sh`. Prometheus alerts `WatchdogServiceDown` and `NodePingableButNotReady` (monitoring-stack **0.2.10**). See `docs/NODE-1-HANG-2026-05-26-SECOND.md`.
+
 ### Changed
 
 - **Prometheus (monitoring-stack 0.2.9)** — Moved `extraSecretMounts` / `extraConfigmapMounts` scrape config paths from `/etc/config/*.yaml` to `/etc/scrape-configs/*.yaml`. Root cause: the kubelet creates an empty placeholder directory in the `config-volume` backing store for every subPath mount that targets a path inside `/etc/config/`. runc then fails to bind-mount the file over that directory (`MS_BIND|MS_REC` on a file-vs-directory path → `ENOTDIR`), causing Prometheus CrashLoopBackOff (568 restarts, 47 h) with `not a directory` in the containerd shim error. Using a separate `/etc/scrape-configs/` directory avoids the collision entirely; ClusterIP scrape via Prometheus `scrapeConfigFiles` unchanged. `clusters/eldertree/observability/monitoring-stack-helmrelease.yaml` chart `0.2.9`.

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -11,7 +11,16 @@ all:
       hosts:
         node-1:
           ansible_host: 192.168.2.101
+          watchdog_ping_peers:
+            - "{{ node_2_eth0_ip }}"
+            - "{{ node_3_eth0_ip }}"
         node-2:
           ansible_host: 192.168.2.102
+          watchdog_ping_peers:
+            - "{{ node_1_eth0_ip }}"
+            - "{{ node_3_eth0_ip }}"
         node-3:
           ansible_host: 192.168.2.103
+          watchdog_ping_peers:
+            - "{{ node_1_eth0_ip }}"
+            - "{{ node_2_eth0_ip }}"

--- a/ansible/playbooks/setup-hardware-watchdog.yml
+++ b/ansible/playbooks/setup-hardware-watchdog.yml
@@ -6,6 +6,8 @@
 - name: Setup Hardware Watchdog
   hosts: raspberry_pi
   become: true
+  vars_files:
+    - ../group_vars/all.yml
 
   tasks:
     - name: Install watchdog daemon
@@ -13,6 +15,38 @@
         name: watchdog
         state: present
         update_cache: no
+
+    # Raspberry Pi OS ships a systemd drop-in that enables RuntimeWatchdogSec=1m.
+    # That claims /dev/watchdog before the watchdog daemon, so the daemon shows
+    # "active" but alive=[none] and the node is not protected (see NODE-1-HANG doc).
+    - name: Stat Raspberry Pi systemd watchdog drop-in
+      stat:
+        path: /usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf
+      register: rpi_watchdog_dropin
+    - name: Disable Raspberry Pi systemd hardware watchdog drop-in (when present)
+      command: mv /usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf /usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf.disabled
+      when: rpi_watchdog_dropin.stat.exists
+      notify:
+        - reload systemd
+        - restart watchdog
+
+    - name: Ensure systemd does not use the hardware watchdog device
+      lineinfile:
+        path: /etc/systemd/system.conf
+        regexp: '^RuntimeWatchdogSec='
+        line: 'RuntimeWatchdogSec=0'
+        insertafter: '^\[Manager\]'
+      notify:
+        - reload systemd
+        - restart watchdog
+
+    - name: Install k3s health check script for watchdog test-binary
+      template:
+        src: ../templates/watchdog-k3s-health.sh.j2
+        dest: /usr/local/bin/watchdog-k3s-health.sh
+        owner: root
+        group: root
+        mode: '0755'
 
     - name: Create watchdog config
       template:
@@ -22,6 +56,21 @@
         group: root
         mode: '0644'
         backup: yes
+      notify: restart watchdog
+
+    - name: Enable persistent systemd journal storage
+      lineinfile:
+        path: /etc/systemd/journald.conf
+        regexp: '^#?Storage='
+        line: 'Storage=persistent'
+      notify: restart journald
+
+    - name: Set journal disk usage limit
+      lineinfile:
+        path: /etc/systemd/journald.conf
+        regexp: '^#?SystemMaxUse='
+        line: 'SystemMaxUse=500M'
+      notify: restart journald
 
     - name: Enable watchdog service
       systemd:
@@ -38,6 +87,12 @@
     - name: Display watchdog status
       debug:
         msg: "Watchdog daemon is active on {{ inventory_hostname }}"
+
+    - name: Verify watchdog daemon holds /dev/watchdog
+      shell: lsof /dev/watchdog 2>/dev/null | awk 'NR>1 && $1=="watchdog" {found=1} END {exit !found}'
+      register: watchdog_device_holder
+      changed_when: false
+      failed_when: watchdog_device_holder.rc != 0
 
     # Boot Loop Protection
     - name: Create boot guard script
@@ -99,8 +154,21 @@
 
   handlers:
     - name: restart watchdog
+      block:
+        - name: Restart watchdog service
+          systemd:
+            name: watchdog
+            state: restarted
+      rescue:
+        - name: Start watchdog after failed restart
+          systemd:
+            name: watchdog
+            state: started
+            enabled: yes
+
+    - name: restart journald
       systemd:
-        name: watchdog
+        name: systemd-journald
         state: restarted
 
     - name: reload systemd

--- a/ansible/templates/watchdog-k3s-health.sh.j2
+++ b/ansible/templates/watchdog-k3s-health.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Health check for hardware watchdog (test-binary).
+# Exit 0 = healthy; non-zero triggers repair/reboot via watchdog daemon.
+set -euo pipefail
+
+if ! systemctl is-active --quiet k3s; then
+  logger -t watchdog-k3s-health "k3s service not active"
+  exit 1
+fi
+
+if ! curl -sf --max-time 5 http://127.0.0.1:10248/healthz >/dev/null; then
+  logger -t watchdog-k3s-health "kubelet healthz check failed"
+  exit 1
+fi
+
+if ! ss -ltn | grep -q ':6443'; then
+  logger -t watchdog-k3s-health "k3s API not listening on :6443"
+  exit 1
+fi
+
+exit 0

--- a/ansible/templates/watchdog.conf.j2
+++ b/ansible/templates/watchdog.conf.j2
@@ -1,37 +1,18 @@
 # Watchdog configuration for Raspberry Pi K3s cluster
-# Automatically reboots node if system becomes unresponsive
-# See: https://github.com/raolivei/pi-fleet/issues/153
+# Managed by Ansible — see docs/HARDWARE_WATCHDOG.md
 
-# Hardware watchdog device (BCM2835 on Raspberry Pi)
 watchdog-device = /dev/watchdog
-
-# Timeout before reboot (seconds)
-# Set to 15s - allows time for safe shutdown before forced reboot
 watchdog-timeout = {{ watchdog_timeout }}
-
-# Daemon interval to kick watchdog (seconds)
 interval = 5
-
-# Maximum 1-minute load average before triggering reboot
 max-load-1 = {{ watchdog_max_load }}
 
-# Note: pidfile check disabled because k3s doesn't create /var/run/k3s.pid
-# Cluster health is monitored via node pings instead
+# Peer gigabit IPs only (not self) — reboot when ALL peers unreachable
+{% for peer in watchdog_ping_peers %}
+ping = {{ peer }}
+{% endfor %}
 
-# Ping cluster nodes via gigabit network for peer health checks
-# These are contacted on 10.0.0.0/24 internal network
-ping = 10.0.0.1
-ping = 10.0.0.2
-ping = 10.0.0.3
+# k3s/kubelet/API health (catches pingable-but-frozen hangs)
+test-binary = /usr/local/bin/watchdog-k3s-health.sh
+test-timeout = 30
 
-# Fork into background
-daemonize = yes
-
-# Log file
-logfile = /var/log/watchdog.log
-
-# Repair processes instead of killing them
 repair-binary = /usr/bin/systemctl
-
-# Verbose logging
-verbose = yes

--- a/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
+++ b/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/monitoring-stack
-      version: "0.2.9"
+      version: "0.2.10"
       sourceRef:
         kind: GitRepository
         name: flux-system

--- a/docs/HARDWARE_WATCHDOG.md
+++ b/docs/HARDWARE_WATCHDOG.md
@@ -41,8 +41,8 @@ To prevent infinite reboot loops, a boot guard tracks consecutive reboots:
 | `watchdog-timeout` | 15s | Hardware timeout before forced reboot |
 | `interval` | 5s | How often daemon kicks watchdog |
 | `max-load-1` | 24 | Reboot if 1-min load avg exceeds this |
-| `ping` | 10.0.0.x | Check cluster node connectivity via gigabit |
-| `pidfile` | /var/run/k3s.pid | Verify k3s service is running |
+| `ping` | peer 10.0.0.x only | Each node pings **other** nodes (not self); reboot if **all** peers unreachable |
+| `test-binary` | `/usr/local/bin/watchdog-k3s-health.sh` | k3s active, kubelet `/healthz`, API `:6443` |
 | `watchdog_max_boot_attempts` | 5 | Max consecutive reboots before disabling watchdog |
 | `watchdog_successful_boot_time` | 600s | Time node must stay up to reset boot counter |
 
@@ -69,9 +69,16 @@ ansible-playbook -i inventory/hosts.yml \
 
 ## Verification
 
+### All nodes (from laptop)
+```bash
+./scripts/verify-watchdog.sh
+```
+Checks: service active, RPI drop-in absent, `watchdog` process holds `/dev/watchdog` (uses WiFi `192.168.2.10x` if gigabit SSH fails).
+
 ### Service Status
 ```bash
-ssh raolivei@10.0.0.1 "systemctl status watchdog"
+ssh raolivei@192.168.2.101 "systemctl status watchdog"
+sudo lsof /dev/watchdog   # must show watchdog daemon, not wd_keepalive alone
 ```
 
 ### Logs

--- a/docs/NODE-1-HANG-2026-05-26-SECOND.md
+++ b/docs/NODE-1-HANG-2026-05-26-SECOND.md
@@ -1,0 +1,40 @@
+# Node-1 Second Hang - May 26–27, 2026
+
+## Summary
+
+Node-1 hung again **~21:59 EDT May 26** (~3 hours after the first watchdog fix). Manual reboot **~13:26 EDT May 27**. Hardware watchdog did **not** auto-reboot.
+
+## Timeline
+
+| Time (EDT) | Event |
+|------------|--------|
+| May 26 18:33 | First hang fixed — removed `40-rpi-enable-watchdog.conf` on node-1 |
+| May 26 20:37 | Verified node-1 `alive=/dev/watchdog` |
+| May 26 21:11+ | Node-3 watchdog logs: `no response from ping (target: 10.0.0.1)` |
+| May 26 21:59 | Kubelet last heartbeat; node NotReady ~22:00 |
+| May 27 13:26 | Manual reboot; journals from hung boot **not retained** |
+| May 27 15:51 | node-2/node-3 RPI drop-in disabled; all nodes verified protected |
+
+## Symptoms
+
+- ICMP to `192.168.2.101` worked; SSH to `10.0.0.1` **connection reset**
+- Kubelet stopped posting status; classic “pingable but dead” pattern (same as Feb 2026)
+
+## Why watchdog did not reboot
+
+1. **Ping + load checks insufficient** — partial gigabit failure or daemon still pinging peers while kubelet/SSH frozen.
+2. **No application health check** — until May 27 hardening, no `test-binary` for k3s/kubelet/API.
+3. **Peer ping does not reboot this node** — node-3 seeing node-1 down does not reboot node-3 (by design).
+
+## Mitigations deployed
+
+- `watchdog-k3s-health.sh` test-binary (k3s, kubelet healthz, :6443)
+- Peer-only ping targets (no self-ping)
+- `scripts/verify-watchdog.sh` — device ownership + RPI drop-in
+- Prometheus: `NodePingableButNotReady`, `WatchdogServiceDown`
+- Persistent journald on all nodes for future forensics
+
+## Related
+
+- [NODE-1-HANG-ROOT-CAUSE-2026-05-26.md](NODE-1-HANG-ROOT-CAUSE-2026-05-26.md) — systemd vs daemon device conflict
+- [HARDWARE_WATCHDOG.md](HARDWARE_WATCHDOG.md) — operations guide

--- a/docs/NODE-1-HANG-ROOT-CAUSE-2026-05-26.md
+++ b/docs/NODE-1-HANG-ROOT-CAUSE-2026-05-26.md
@@ -37,11 +37,9 @@ The watchdog daemon has been unable to open `/dev/watchdog` since boot because *
 - Our watchdog daemon checks load average and network connectivity - systemd's doesn't
 - 1-minute timeout is much longer than our configured 15-second timeout
 
-### Why Node-2 and Node-3 Work Correctly
+### Node-2 and Node-3 (corrected May 27, 2026)
 
-Checked node-2 and node-3 - **neither have systemd using the watchdog**. They both have the watchdog daemon successfully running and protecting the system.
-
-**This suggests node-1 has a different systemd configuration or was set up differently.**
+Initial investigation suggested only node-1 had the conflict. **Follow-up showed all three nodes** had `/usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf`, causing `watchdog.service` to show **active** while `alive=[none]` (no `/dev/watchdog` access). Node-1 was fixed May 26; node-2 and node-3 were fixed May 27. Use `scripts/verify-watchdog.sh` — do not trust `systemctl is-active watchdog` alone.
 
 ## Resolution
 

--- a/helm/monitoring-stack/Chart.yaml
+++ b/helm/monitoring-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring-stack
 description: Complete monitoring stack with Prometheus and Grafana for pi-fleet
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: "1.0"
 dependencies:
   - name: prometheus

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -32,6 +32,10 @@ prometheus:
         cert-manager.io/cluster-issuer: ca-cluster-issuer
   nodeExporter:
     enabled: true
+  prometheus-node-exporter:
+    extraArgs:
+      - --collector.systemd
+      - --collector.systemd.unit-include=watchdog.service
   pushgateway:
     enabled: true
     persistentVolume:
@@ -256,6 +260,32 @@ prometheus:
               annotations:
                 summary: "OOM kill detected on {{ $labels.instance }}"
                 description: "{{ $labels.instance }} killed {{ $value }} process(es) due to out-of-memory. Check pod memory limits and node capacity."
+            - alert: WatchdogServiceDown
+              expr: node_systemd_unit_state{name="watchdog.service",state="active"} != 1
+              for: 3m
+              labels:
+                severity: critical
+              annotations:
+                summary: "Watchdog service not active on {{ $labels.instance }}"
+                description: "watchdog.service is not active on {{ $labels.instance }}. Hardware watchdog may not be armed — run scripts/verify-watchdog.sh."
+            - alert: NodePingableButNotReady
+              expr: |
+                (
+                  (kube_node_status_condition{condition="Ready",status="true",node="node-1.eldertree.local"} == 0
+                   and up{instance="10.0.0.1:9100"} == 1)
+                  or
+                  (kube_node_status_condition{condition="Ready",status="true",node="node-2.eldertree.local"} == 0
+                   and up{instance="10.0.0.2:9100"} == 1)
+                  or
+                  (kube_node_status_condition{condition="Ready",status="true",node="node-3.eldertree.local"} == 0
+                   and up{instance="10.0.0.3:9100"} == 1)
+                )
+              for: 5m
+              labels:
+                severity: critical
+              annotations:
+                summary: "Node {{ $labels.node }} metrics up but NotReady"
+                description: "node-exporter is reachable but the node is NotReady for 5m — possible freeze (ICMP up, kubelet dead). Check watchdog and journalctl."
         - name: kubernetes-alerts
           rules:
             - alert: PodCrashLooping

--- a/scripts/verify-watchdog.sh
+++ b/scripts/verify-watchdog.sh
@@ -1,71 +1,93 @@
 #!/bin/bash
-# Verify hardware watchdog status on all eldertree nodes
+# Verify hardware watchdog status on all eldertree nodes.
+# Checks service state AND whether the daemon actually holds /dev/watchdog.
 
-set -e
+set -euo pipefail
 
-NODES=("10.0.0.1" "10.0.0.2" "10.0.0.3")
-NAMES=("node-1" "node-2" "node-3")
-SSH_KEY="~/.ssh/id_ed25519_raolivei"
+# Prefer gigabit; fall back to WiFi when SSH from a laptop fails on 10.0.0.x
+NODE_NAMES=("node-1" "node-2" "node-3")
+NODE_IPS_GB=("10.0.0.1" "10.0.0.2" "10.0.0.3")
+NODE_IPS_WIFI=("192.168.2.101" "192.168.2.102" "192.168.2.103")
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_raolivei}"
 SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=5"
+
+ssh_node() {
+  local ip=$1
+  shift
+  ssh $SSH_OPTS -i "$SSH_KEY" "raolivei@${ip}" "$@"
+}
+
+resolve_ip() {
+  local idx=$1
+  local ip
+  for ip in "${NODE_IPS_GB[$idx]}" "${NODE_IPS_WIFI[$idx]}"; do
+    if ssh_node "$ip" "exit" 2>/dev/null; then
+      echo "$ip"
+      return 0
+    fi
+  done
+  return 1
+}
 
 echo "=== Hardware Watchdog Status Check ==="
 echo "Date: $(date)"
 echo ""
 
-for i in "${!NODES[@]}"; do
-  NODE="${NODES[$i]}"
-  NAME="${NAMES[$i]}"
+FAILURES=0
 
-  echo "--- $NAME ($NODE) ---"
-
-  # Check if node is reachable
-  if ! ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "exit" 2>/dev/null; then
-    echo "✗ Node unreachable (SSH failed)"
+for i in "${!NODE_NAMES[@]}"; do
+  NAME="${NODE_NAMES[$i]}"
+  IP=""
+  if ! IP=$(resolve_ip "$i"); then
+    echo "--- $NAME (unreachable) ---"
+    echo "✗ SSH failed on ${NODE_IPS_GB[$i]} and ${NODE_IPS_WIFI[$i]}"
     echo ""
+    FAILURES=$((FAILURES + 1))
     continue
   fi
 
-  # Service status
-  if ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "systemctl is-active watchdog" 2>/dev/null | grep -q "active"; then
+  echo "--- $NAME ($IP) ---"
+
+  if ssh_node "$IP" "systemctl is-active watchdog" 2>/dev/null | grep -q "active"; then
     echo "✓ Service: running"
   else
     echo "✗ Service: NOT RUNNING"
+    FAILURES=$((FAILURES + 1))
   fi
 
-  # Boot counter
-  COUNTER=$(ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "cat /var/lib/watchdog-boot-count 2>/dev/null" || echo "N/A")
+  if ssh_node "$IP" "test ! -f /usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf" 2>/dev/null; then
+    echo "✓ RPI systemd drop-in: absent (good)"
+  else
+    echo "✗ RPI systemd drop-in: PRESENT — disables hardware watchdog for daemon"
+    FAILURES=$((FAILURES + 1))
+  fi
+
+  if ssh_node "$IP" "sudo lsof /dev/watchdog 2>/dev/null | awk 'NR>1 && \$1==\"watchdog\" {found=1} END {exit !found}'" 2>/dev/null; then
+    echo "✓ Device: watchdog daemon holds /dev/watchdog"
+  else
+    echo "✗ Device: watchdog daemon does NOT hold /dev/watchdog"
+    ssh_node "$IP" "sudo lsof /dev/watchdog 2>/dev/null | head -3" || true
+    FAILURES=$((FAILURES + 1))
+  fi
+
+  COUNTER=$(ssh_node "$IP" "cat /var/lib/watchdog-boot-count 2>/dev/null" || echo "N/A")
   echo "Boot counter: $COUNTER"
-
-  if [ "$COUNTER" != "N/A" ] && [ "$COUNTER" -ge 5 ]; then
-    echo "⚠️  WARNING: Boot counter at max ($COUNTER/5) - watchdog may be disabled!"
+  if [ "$COUNTER" != "N/A" ] && [ "$COUNTER" -ge 5 ] 2>/dev/null; then
+    echo "⚠️  WARNING: Boot counter at max ($COUNTER/5)"
   fi
 
-  # Recent reboots (last 24 hours)
-  REBOOTS=$(ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "journalctl -u watchdog --since '24 hours ago' 2>/dev/null | grep -c 'stopping\|started'" 2>/dev/null || echo "0")
-  echo "Watchdog restarts (24h): $REBOOTS"
+  LAST_REBOOT=$(ssh_node "$IP" "awk '/btime/ {print \$2}' /proc/stat | xargs -I{} date -d @{} 2>/dev/null" || echo "unknown")
+  echo "Kernel boot time: $LAST_REBOOT"
 
-  # Last reboot time
-  LAST_REBOOT=$(ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "uptime -s 2>/dev/null" || echo "unknown")
-  echo "System boot time: $LAST_REBOOT"
-
-  # Check configuration
-  TIMEOUT=$(ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "grep -E '^watchdog-timeout' /etc/watchdog.conf 2>/dev/null | awk '{print \$3}'" || echo "N/A")
+  TIMEOUT=$(ssh_node "$IP" "grep -E '^watchdog-timeout' /etc/watchdog.conf 2>/dev/null | awk '{print \$3}'" || echo "N/A")
   echo "Watchdog timeout: ${TIMEOUT}s"
-
-  # Check for recent watchdog activity
-  LAST_LOG=$(ssh $SSH_OPTS -i $SSH_KEY raolivei@$NODE "journalctl -u watchdog --since '1 hour ago' --no-pager 2>/dev/null | tail -1" || echo "No recent logs")
-  if [ "$LAST_LOG" != "No recent logs" ]; then
-    echo "Last watchdog log: $(echo "$LAST_LOG" | cut -c1-80)..."
-  fi
-
   echo ""
 done
 
 echo "=== Summary ==="
-echo "Check complete. Review any warnings above."
-echo ""
-echo "To check detailed logs on a specific node:"
-echo "  ssh raolivei@10.0.0.X 'journalctl -u watchdog -n 50'"
-echo ""
-echo "To check system logs from previous boot:"
-echo "  ssh raolivei@10.0.0.X 'journalctl --boot=-1 | tail -100'"
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All nodes protected (daemon holds /dev/watchdog)."
+else
+  echo "$FAILURES check(s) failed — see warnings above."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Disable Raspberry Pi `40-rpi-enable-watchdog.conf` via Ansible so the watchdog **daemon** holds `/dev/watchdog` (not systemd with `alive=[none]`).
- Add `watchdog-k3s-health.sh` test-binary: k3s active, kubelet `/healthz`, API `:6443` — catches pingable-but-frozen hangs.
- Peer-only gigabit ping targets per node; persistent journald (`Storage=persistent`, `SystemMaxUse=500M`).
- Improve `scripts/verify-watchdog.sh` (WiFi fallback, drop-in + device checks).
- Prometheus monitoring-stack **0.2.10**: `WatchdogServiceDown`, `NodePingableButNotReady`; enable systemd collector for watchdog unit.
- Docs: second node-1 incident, corrected root-cause doc, ops handoff agent.

## Applied on cluster (pre-merge)

- Ansible playbook run on all 3 nodes; rolling reboot node-3 → node-2; `verify-watchdog.sh` passes on all nodes.

## Test plan

- [x] `./scripts/verify-watchdog.sh` — all nodes green
- [x] `/usr/local/bin/watchdog-k3s-health.sh` exits 0 on each node
- [x] `grep ping /etc/watchdog.conf` — peer IPs only (no self-ping)
- [ ] After merge: `flux reconcile helmrelease monitoring-stack -n observability`
- [ ] Confirm Prometheus rules load without errors
- [ ] Optional: `ansible-playbook playbooks/setup-hardware-watchdog.yml` idempotent re-run


Made with [Cursor](https://cursor.com)