### PR TITLE
fix: Prometheus scrape_config_files YAML format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Prometheus scrape config files** — Pi-hole, Visage, and Vault files under `/etc/scrape-configs/` must use a top-level `scrape_configs:` key (not a bare YAML list). Fixes Prometheus CrashLoop `cannot unmarshal !!seq into config.ScrapeConfigs` after monitoring-stack 0.2.10.
 - **Hardware watchdog (all nodes)** — Disable Raspberry Pi OS `40-rpi-enable-watchdog.conf` and set `RuntimeWatchdogSec=0` so the watchdog daemon holds `/dev/watchdog`. Add `watchdog-k3s-health.sh` test-binary (k3s, kubelet healthz, API :6443), peer-only ping targets, persistent journald, improved `scripts/verify-watchdog.sh`. Prometheus alerts `WatchdogServiceDown` and `NodePingableButNotReady` (monitoring-stack **0.2.10**). See `docs/NODE-1-HANG-2026-05-26-SECOND.md`.
 
 ### Changed

--- a/clusters/eldertree/observability/pihole-scrape-config.yaml
+++ b/clusters/eldertree/observability/pihole-scrape-config.yaml
@@ -6,16 +6,17 @@ metadata:
 type: Opaque
 stringData:
   pihole-scrape.yaml: |
-    - job_name: 'pihole'
-      scrape_interval: 60s
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      static_configs:
-        - targets:
-          - 'pi-hole.pihole.svc.cluster.local:9617'
-          labels:
-            service: pihole
-            namespace: pihole
+    scrape_configs:
+      - job_name: 'pihole'
+        scrape_interval: 60s
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        static_configs:
+          - targets:
+              - 'pi-hole.pihole.svc.cluster.local:9617'
+            labels:
+              service: pihole
+              namespace: pihole
 
 
 

--- a/clusters/eldertree/observability/vault-scrape-config.yaml
+++ b/clusters/eldertree/observability/vault-scrape-config.yaml
@@ -9,17 +9,18 @@ metadata:
     prometheus-scrape-config: "true"
 data:
   vault-scrape.yaml: |
-    - job_name: 'vault'
-      metrics_path: /v1/sys/metrics
-      params:
-        format: ['prometheus']
-      scrape_interval: 60s
-      scrape_timeout: 10s
-      static_configs:
-        - targets:
-          - 'vault.vault.svc.cluster.local:8200'
-          labels:
-            service: vault
-            namespace: vault
+    scrape_configs:
+      - job_name: 'vault'
+        metrics_path: /v1/sys/metrics
+        params:
+          format: ['prometheus']
+        scrape_interval: 60s
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+              - 'vault.vault.svc.cluster.local:8200'
+            labels:
+              service: vault
+              namespace: vault
       # Vault metrics endpoint requires authentication unless unauthenticated_metrics_access is enabled
       # For now, we'll try without auth - if it fails, we'll need to add a token

--- a/clusters/eldertree/observability/visage-scrape-config.yaml
+++ b/clusters/eldertree/observability/visage-scrape-config.yaml
@@ -9,26 +9,27 @@ metadata:
     prometheus-scrape-config: "true"
 data:
   visage-scrape.yaml: |
-    - job_name: 'visage-api'
-      kubernetes_sd_configs:
-        - role: endpoints
-          namespaces:
-            names:
-              - visage
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
-          action: keep
-          regex: visage-api;http
-        - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
-        - source_labels: [__meta_kubernetes_service_name]
-          target_label: service
-      metrics_path: /metrics
-      scrape_interval: 60s
-    - job_name: 'visage-redis'
-      scrape_interval: 60s
-      static_configs:
-        - targets: ['visage-redis.visage.svc.cluster.local:6379']
-          labels:
-            service: visage-redis
-            namespace: visage
+    scrape_configs:
+      - job_name: 'visage-api'
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - visage
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: visage-api;http
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            target_label: service
+        metrics_path: /metrics
+        scrape_interval: 60s
+      - job_name: 'visage-redis'
+        scrape_interval: 60s
+        static_configs:
+          - targets: ['visage-redis.visage.svc.cluster.local:6379']
+            labels:
+              service: visage-redis
+              namespace: visage


### PR DESCRIPTION
## Summary

- Wrap Pi-hole, Visage, and Vault scrape fragments with top-level `scrape_configs:` (required by Prometheus `scrape_config_files`).
- Fixes CrashLoop: `cannot unmarshal !!seq into config.ScrapeConfigs`.

## Test plan

- [x] Applied to cluster; Prometheus server restarted
- [ ] Prometheus pod 2/2 Ready
- [ ] `kubectl exec` promtool check config loads
- [ ] Watchdog alert rules visible in Prometheus UI


Made with [Cursor](https://cursor.com)