### PR TITLE
docs: eldertree-chassis and TL-SG1008MP references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Added
+
+- **Hardware** — [`docs/HARDWARE_CHASSIS.md`](docs/HARDWARE_CHASSIS.md) links mechanical CAD to [eldertree-chassis](https://github.com/raolivei/eldertree-chassis); README hardware section updated.
+
+### Changed
+
+- **Docs** — Worker-node and `check-new-pi.sh` switch references updated from legacy TP-Link SG105 to **TL-SG1008MP** (PoE+ cluster switch).
+
 ### Fixed
 
 - **Hardware watchdog (all nodes)** — Disable Raspberry Pi OS `40-rpi-enable-watchdog.conf` and set `RuntimeWatchdogSec=0` so the watchdog daemon holds `/dev/watchdog`. Add `watchdog-k3s-health.sh` test-binary (k3s, kubelet healthz, API :6443), peer-only ping targets, persistent journald, improved `scripts/verify-watchdog.sh`. Prometheus alerts `WatchdogServiceDown` and `NodePingableButNotReady` (monitoring-stack **0.2.10**). See `docs/NODE-1-HANG-2026-05-26-SECOND.md`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ K3s cluster on Raspberry Pi, managed with Ansible and Terraform.
 
 - Raspberry Pi 5 (8GB, ARM64)
 - Debian 12 Bookworm
+- Physical tower (CAD / BOM): [**eldertree-chassis**](https://github.com/raolivei/eldertree-chassis) — [docs/HARDWARE_CHASSIS.md](docs/HARDWARE_CHASSIS.md)
 
 ## Cluster Nodes
 

--- a/docs/ADD_WORKER_NODE.md
+++ b/docs/ADD_WORKER_NODE.md
@@ -9,7 +9,7 @@ Complete guide for adding a new Raspberry Pi as a worker node to your k3s cluste
 - ✅ Raspberry Pi 5 (8GB recommended, ARM64)
 - ✅ MicroSD card (32GB+ recommended, Class 10 or better)
 - ✅ Power supply for Raspberry Pi 5
-- ✅ Ethernet cable (connected to TP-Link SG105 switch)
+- ✅ Ethernet cable (connected to TP-Link TL-SG1008MP PoE+ switch on eth0 fabric)
 - ✅ SD card reader/adapter for your Mac
 
 ### 2. Software Requirements
@@ -64,7 +64,7 @@ Complete guide for adding a new Raspberry Pi as a worker node to your k3s cluste
 
 7. **Boot the Pi**:
    - Insert microSD card into Raspberry Pi
-   - Connect Ethernet cable to TP-Link SG105 switch
+   - Connect Ethernet cable to TL-SG1008MP switch (eth0 / `10.0.0.0/24`)
    - Connect power supply
    - Wait for boot (30-60 seconds)
    - The Pi will automatically get an IP address via DHCP
@@ -94,7 +94,7 @@ ping raspberrypi.local
 
 ### Option 4: Check Switch/Network
 
-Since both Pis are on the TP-Link SG105 switch, check which IPs are active:
+Since nodes share the isolated cluster switch (TL-SG1008MP), check which eth0 IPs are active:
 
 ```bash
 # Check which IPs respond to ping

--- a/docs/HARDWARE_CHASSIS.md
+++ b/docs/HARDWARE_CHASSIS.md
@@ -1,0 +1,29 @@
+# ElderTree physical chassis
+
+Cluster **software and operations** are documented in this repo. **Mechanical CAD** (OpenSCAD, prints, assembly) lives in [**eldertree-chassis**](https://github.com/raolivei/eldertree-chassis).
+
+## Hardware summary
+
+| Layer | Component |
+|-------|-----------|
+| Base | EcoFlow River 3 (UPS / portable AC) |
+| Network | TP-Link TL-SG1008MP (8-port PoE+) |
+| Compute | 3× Raspberry Pi 5 (8GB), NVMe boot, M.2 NVMe M-key & PoE+ HAT |
+| Cooling | Open-frame airflow; 120 mm top exhaust; HAT fans (Ansible `poe_fan_temp*`) |
+
+**Power path:** River 3 AC → switch → PoE+ to each Pi.
+
+**Cluster network:** eth0 on isolated `10.0.0.0/24` via switch ([GIGABIT_NETWORK_SETUP.md](GIGABIT_NETWORK_SETUP.md)); wlan0 on `192.168.2.101–103`.
+
+## Documentation map
+
+| Topic | Location |
+|-------|----------|
+| Dimensions, BOM, prints | [eldertree-chassis/docs/](https://github.com/raolivei/eldertree-chassis/tree/main/docs) |
+| Parametric source | [config.scad](https://github.com/raolivei/eldertree-chassis/blob/main/cad/openscad/config.scad) |
+| Assembly / power-on | [assembly.md](https://github.com/raolivei/eldertree-chassis/blob/main/docs/assembly.md) |
+| Runbook (physical) | [eldertree-docs runbook](https://docs.eldertree.xyz/runbook/hardware/chassis) |
+
+## Cluster switch
+
+The eldertree **eth0** fabric uses an isolated **TP-Link TL-SG1008MP** (PoE+, 153 W budget). Older pi-fleet docs referenced a non-PoE **SG105** during bring-up; treat SG1008MP as current for chassis and eth0 cabling.

--- a/scripts/operations/check-new-pi.sh
+++ b/scripts/operations/check-new-pi.sh
@@ -132,8 +132,8 @@ fi
 
 echo ""
 echo -e "${BLUE}=== Switch Information ===${NC}"
-echo "TP-Link SG105: 5-port Gigabit switch"
-echo "Both Pis should be connected to this switch"
+echo "TP-Link TL-SG1008MP: 8-port Gigabit PoE+ switch (eth0 cluster fabric)"
+echo "Nodes use eth0 on 10.0.0.0/24 — see docs/GIGABIT_NETWORK_SETUP.md"
 echo "Network: $NETWORK"
 echo ""
 


### PR DESCRIPTION
## Summary
- Adds `docs/HARDWARE_CHASSIS.md` linking [eldertree-chassis](https://github.com/raolivei/eldertree-chassis)
- Updates legacy TP-Link SG105 mentions to **TL-SG1008MP** (PoE+ cluster switch)
- README hardware cross-link

Replaces #186 (had merge conflicts).

## Test plan
- [ ] Links resolve

Made with [Cursor](https://cursor.com)