### PR TITLE
fix: skip Terraform CI on Dependabot PRs without TF_API_TOKEN

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -74,7 +74,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Dependabot PRs do not receive repository secrets (e.g. TF_API_TOKEN) unless
+      # Settings → Secrets and variables → Actions → Dependabot is enabled.
+      - name: Check Terraform Cloud credentials
+        id: tf_auth
+        working-directory: .
+        run: |
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Terraform CI skipped::Dependabot PRs do not receive TF_API_TOKEN. See terraform/README.md (CI/CD)."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Terraform
+        if: steps.tf_auth.outputs.skip != 'true'
         uses: hashicorp/setup-terraform@v4
         with:
           # 1.6.x fails provider install with openpgp: key expired (HashiCorp key rotation)
@@ -87,6 +101,7 @@ jobs:
       # Pre-configure Vault dev server with backends that exist in TF state
       # so the provider doesn't crash during PlanResourceChange calls
       - name: Configure Vault Dev Server
+        if: steps.tf_auth.outputs.skip != 'true'
         run: |
           # Wait for Vault to be ready
           for i in 1 2 3 4 5; do
@@ -102,10 +117,12 @@ jobs:
         working-directory: .
 
       - name: Terraform Init
+        if: steps.tf_auth.outputs.skip != 'true'
         run: terraform init -input=false
 
       # Redirect to file (not pipe) to avoid EPIPE when piping terraform output
       - name: Verify Remote State
+        if: steps.tf_auth.outputs.skip != 'true'
         id: remote_state
         run: |
           if terraform state list > state-list.txt 2>&1; then
@@ -130,14 +147,17 @@ jobs:
           rm -f state-list.txt
 
       - name: Terraform Format Check
+        if: steps.tf_auth.outputs.skip != 'true'
         run: terraform fmt -check -recursive
 
       - name: Terraform Validate
+        if: steps.tf_auth.outputs.skip != 'true'
         run: terraform validate
 
       # -refresh=false: use cached state, don't refresh from providers
       # Vault dev server satisfies provider init; -refresh=false avoids state drift
       - name: Terraform Plan
+        if: steps.tf_auth.outputs.skip != 'true'
         id: plan
         run: |
           set +e
@@ -170,6 +190,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         if: |
+          steps.tf_auth.outputs.skip != 'true' &&
           steps.plan.outcome == 'success' &&
           (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
@@ -177,8 +198,20 @@ jobs:
           )
         run: terraform apply -auto-approve -input=false -refresh=false
 
+      - name: Dependabot skip summary
+        if: steps.tf_auth.outputs.skip == 'true'
+        working-directory: .
+        run: |
+          {
+            echo "## Terraform CI skipped (Dependabot)"
+            echo ""
+            echo "GitHub does not pass repository secrets (including \`TF_API_TOKEN\` for Terraform Cloud) to workflows triggered by Dependabot unless **Settings → Secrets and variables → Actions → Dependabot** is enabled."
+            echo ""
+            echo "For GitHub Actions-only bumps, merge after review if \`main\` is green. For \`terraform/**\` changes, enable Dependabot secrets or push a branch from a human account to run plan."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Job summary
-        if: always()
+        if: always() && steps.tf_auth.outputs.skip != 'true'
         run: |
           {
             echo "## Terraform run summary"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Terraform CI (Dependabot)** — Skip init/plan when `github.actor` is `dependabot[bot]` (no `TF_API_TOKEN`); document Dependabot secret access in `terraform/README.md`.
 - **Prometheus scrape config files** — Pi-hole, Visage, and Vault fragments use top-level `scrape_configs:` (fixes CrashLoop `cannot unmarshal !!seq into config.ScrapeConfigs`).
 - **Hardware watchdog (all nodes)** — Disable Raspberry Pi OS `40-rpi-enable-watchdog.conf` and set `RuntimeWatchdogSec=0` so the watchdog daemon holds `/dev/watchdog`. Add `watchdog-k3s-health.sh` test-binary (k3s, kubelet healthz, API :6443), peer-only ping targets, persistent journald, improved `scripts/verify-watchdog.sh`. Prometheus alerts `WatchdogServiceDown` and `NodePingableButNotReady` (monitoring-stack **0.2.10**). See `docs/NODE-1-HANG-2026-05-26-SECOND.md`.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -392,16 +392,13 @@ terraform import vault_auth_backend.kubernetes[0] kubernetes
 
 ### CI/CD Behavior
 
-In GitHub Actions, Vault resources are **skipped** (`skip_vault_resources=true`) because:
+The [`.github/workflows/terraform.yml`](../.github/workflows/terraform.yml) job:
 
-1. CI doesn't have direct access to Vault
-2. Vault configuration requires authentication tokens
-3. These resources are typically managed locally or via GitOps
+- Uses **Terraform Cloud** backend (`eldertree` / `pi-fleet-terraform`) via repo secret **`TF_API_TOKEN`** (`hashicorp/setup-terraform` + `cli_config_credentials_token`).
+- Starts a **Vault dev server** service container and sets `skip_vault_resources=false` so Vault resources stay in plan (provider talks to `http://127.0.0.1:8200`).
+- Skips **`terraform apply`** on pull requests (plan-only); apply runs on push to `main` or `workflow_dispatch` with `apply=true`.
 
-To manage Vault via CI, you would need to:
-1. Expose Vault via ingress
-2. Store VAULT_TOKEN in GitHub Secrets
-3. Set `skip_vault_resources=false` in the workflow
+**Dependabot PRs:** GitHub does not pass repository secrets (including `TF_API_TOKEN`) to workflows triggered by `dependabot[bot]` unless you enable **Settings → Secrets and variables → Actions → Dependabot**. Without that, `terraform init` fails with *Required token could not be found*. The workflow detects Dependabot and **skips** init/plan with a green job and a step summary explaining why. Safe to merge Actions-only bumps after review when `main` is green; for `terraform/**` changes, enable Dependabot secrets or push a human branch to get a real plan.
 
 ### Migration from Shell Script
 


### PR DESCRIPTION
## Summary

- Fixes [Terraform CI failure on Dependabot PR #140](https://github.com/raolivei/pi-fleet/actions/runs/26470230653/job/77941386187): `terraform init` failed with *Required token could not be found* because Dependabot workflows do not receive `TF_API_TOKEN` (or other repo secrets) unless **Settings → Secrets → Actions → Dependabot** is enabled.
- When `github.actor` is `dependabot[bot]`, skip init/plan/apply and write a step summary instead of failing.
- Document CI/Dependabot behavior in `terraform/README.md`.

## Test plan

- [ ] Merge PR; re-run or update Dependabot `actions/checkout` PR — Terraform job should succeed with skip summary.
- [ ] Push a non-Dependabot branch touching `terraform/**` — full plan still runs with remote state.


Made with [Cursor](https://cursor.com)