### PR TITLE
feat: Grafana watchdog and node stability panels (0.2.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Changed
+
+- **Grafana (monitoring-stack 0.2.11)** — `hardware-health` and `eldertree-ops-home` panels for watchdog, freeze signal, OOM, and node uptime/reboot (metrics behind `WatchdogServiceDown`, `NodePingableButNotReady`, `NodeUnexpectedReboot`).
+
 ### Added
 
 - **InfraOPS & o11y standards** — Agent [`eldertree-infraops`](.claude/agents/eldertree-infraops.md); [`docs/ONBOARDING_APP_OBSERVABILITY.md`](docs/ONBOARDING_APP_OBSERVABILITY.md); workspace [`OBSERVABILITY_STANDARDS.md`](../workspace-config/docs/OBSERVABILITY_STANDARDS.md) (DRY monitoring checklist).

--- a/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
+++ b/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/monitoring-stack
-      version: "0.2.10"
+      version: "0.2.11"
       sourceRef:
         kind: GitRepository
         name: flux-system

--- a/helm/monitoring-stack/Chart.yaml
+++ b/helm/monitoring-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring-stack
 description: Complete monitoring stack with Prometheus and Grafana for pi-fleet
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "1.0"
 dependencies:
   - name: prometheus

--- a/helm/monitoring-stack/DASHBOARDS.md
+++ b/helm/monitoring-stack/DASHBOARDS.md
@@ -88,7 +88,7 @@ Search in Grafana: **Dashboards** → browse by **folder** (Applications vs Plat
 
 | Dashboard | UID | File | What it shows |
 |-----------|-----|------|----------------|
-| **Eldertree Ops Home** | `eldertree-ops-home` | `eldertree-ops-home.json` | Links to other UIDs, blackbox `probe_success`, Traefik `up`, `swimto_db_users_total` |
+| **Eldertree Ops Home** | `eldertree-ops-home` | `eldertree-ops-home.json` | Links to other UIDs, blackbox `probe_success`, Traefik `up`, SwimTO gauge, Pi node row (Ready, watchdog, freeze signal, OOM) |
 | **Eldertree Command Center** | `eldertree-command-center` | `command-center.json` | Cluster health, resources, Traefik, PVC, top consumers, problem pods |
 | **Eldertree Cluster Overview** | `eldertree-cluster` | `eldertree-cluster.json` | 3-node HA, namespaces, infra + app service rows (summary; not per-app deep dives) |
 
@@ -103,7 +103,7 @@ Search in Grafana: **Dashboards** → browse by **folder** (Applications vs Plat
 | **Kubernetes Workloads** | `kubernetes-workloads` | `kubernetes-workloads.json` | Deployments, StatefulSets, Jobs, restarts, CPU/memory request vs use |
 | **Cluster Resource Usage by Namespace** | `namespace-resources` | `namespace-resources.json` | Per-namespace CPU/memory/network, top consumers, trends |
 | **Network Intelligence** | `network-intelligence` | `network-intelligence.json` | Traefik request rates, codes, top services, node network |
-| **Hardware Health** | `hardware-health` | `hardware-health.json` | Raspberry Pi temperature, load, disk, I/O |
+| **Hardware Health** | `hardware-health` | `hardware-health.json` | Pi temperature, load, disk, I/O; **watchdog.service** per node (`node_systemd_unit_state`), freeze signal, OOM, uptime / reboot (`node_boot_time_seconds`) — aligns with `WatchdogServiceDown`, `NodePingableButNotReady`, `NodeUnexpectedReboot` alerts |
 
 ---
 

--- a/helm/monitoring-stack/dashboards/eldertree-ops-home.json
+++ b/helm/monitoring-stack/dashboards/eldertree-ops-home.json
@@ -5,7 +5,7 @@
   "tags": ["eldertree", "overview", "sre", "featured"],
   "timezone": "browser",
   "schemaVersion": 38,
-  "version": 1,
+  "version": 2,
   "refresh": "1m",
   "editable": true,
   "time": { "from": "now-1h", "to": "now" },
@@ -30,7 +30,7 @@
       "gridPos": { "h": 6, "w": 24, "x": 0, "y": 1 },
       "options": {
         "mode": "markdown",
-        "content": "## Core\n\n- [Command Center](/d/eldertree-command-center) — cluster SLO, resources, top traffic\n- [Eldertree cluster](/d/eldertree-cluster) — 3-node HA, services, Vault row\n- [Network intelligence](/d/network-intelligence) — Traefik ingress, HTTP codes, top services\n- [Kubernetes workloads](/d/kubernetes-workloads) — deploy/statefulset health\n- [Namespace resources](/d/namespace-resources) — quotas and usage by namespace\n\n## Apps (metrics)\n\n- [SwimTO](/d/swimto-dashboard) | [Pitanga](/d/pitanga-dashboard) | [Visage operations](/d/visage-ops) | [Vault](/d/vault-ops)\n\n## Logs (Loki)\n\n**Explore** → **Loki** datasource. Promtail ships node `/var/log/pods` into Loki in `observability`.\n"
+        "content": "## Core\n\n- [Command Center](/d/eldertree-command-center) — cluster SLO, resources, top traffic\n- [Eldertree cluster](/d/eldertree-cluster) — 3-node HA, services, Vault row\n- [Hardware health](/d/hardware-health) — Pi thermals, watchdog, reboots, freeze signal\n- [Network intelligence](/d/network-intelligence) — Traefik ingress, HTTP codes, top services\n- [Kubernetes workloads](/d/kubernetes-workloads) — deploy/statefulset health\n- [Namespace resources](/d/namespace-resources) — quotas and usage by namespace\n\n## Apps (metrics)\n\n- [SwimTO](/d/swimto-dashboard) | [Pitanga](/d/pitanga-dashboard) | [Visage operations](/d/visage-ops) | [Vault](/d/vault-ops)\n\n## Logs (Loki)\n\n**Explore** → **Loki** datasource. Promtail ships node `/var/log/pods` into Loki in `observability`.\n"
       }
     },
     {
@@ -120,6 +120,138 @@
           "refId": "A",
           "expr": "swimto_db_users_total",
           "legendFormat": "users"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Raspberry Pi nodes",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 12 },
+      "collapsed": false
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "K8s nodes Ready",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 13 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "green", "value": 3 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\", status=\"true\"})",
+          "legendFormat": "ready"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Watchdog active (all nodes)",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 13 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 3 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(node_systemd_unit_state{name=\"watchdog.service\",state=\"active\",instance=~\"10.0.0.[1-3]:9100\"})",
+          "legendFormat": "active"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "Freeze signal (exporter up, NotReady)",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 13 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "color": "green", "text": "OK" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum((kube_node_status_condition{condition=\"Ready\",status=\"true\",node=\"node-1.eldertree.local\"} == 0 and up{instance=\"10.0.0.1:9100\"} == 1) or (kube_node_status_condition{condition=\"Ready\",status=\"true\",node=\"node-2.eldertree.local\"} == 0 and up{instance=\"10.0.0.2:9100\"} == 1) or (kube_node_status_condition{condition=\"Ready\",status=\"true\",node=\"node-3.eldertree.local\"} == 0 and up{instance=\"10.0.0.3:9100\"} == 1))",
+          "legendFormat": "nodes"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "OOM kills (5m)",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 13 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(node_vmstat_oom_kill[5m]))",
+          "legendFormat": "kills"
         }
       ]
     }

--- a/helm/monitoring-stack/dashboards/hardware-health.json
+++ b/helm/monitoring-stack/dashboards/hardware-health.json
@@ -9,7 +9,7 @@
     ],
     "timezone": "browser",
     "schemaVersion": 38,
-    "version": 1,
+    "version": 2,
     "refresh": "30s",
     "panels": [
         {
@@ -201,6 +201,357 @@
             "fieldConfig": {
                 "defaults": {
                     "unit": "Bps"
+                }
+            }
+        },
+        {
+            "id": 10,
+            "title": "Watchdog & node stability",
+            "type": "row",
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 27
+            },
+            "collapsed": false
+        },
+        {
+            "id": 11,
+            "title": "Node 1 — watchdog.service",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 0,
+                "y": 28
+            },
+            "targets": [
+                {
+                    "expr": "node_systemd_unit_state{instance=\"10.0.0.1:9100\",name=\"watchdog.service\",state=\"active\"}",
+                    "legendFormat": "node-1",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "type": "value",
+                            "options": {
+                                "1": {
+                                    "color": "green",
+                                    "text": "ACTIVE"
+                                }
+                            }
+                        },
+                        {
+                            "type": "special",
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "color": "red",
+                                    "text": "DOWN"
+                                }
+                            }
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "red",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center"
+            }
+        },
+        {
+            "id": 12,
+            "title": "Node 2 — watchdog.service",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 4,
+                "y": 28
+            },
+            "targets": [
+                {
+                    "expr": "node_systemd_unit_state{instance=\"10.0.0.2:9100\",name=\"watchdog.service\",state=\"active\"}",
+                    "legendFormat": "node-2",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "type": "value",
+                            "options": {
+                                "1": {
+                                    "color": "green",
+                                    "text": "ACTIVE"
+                                }
+                            }
+                        },
+                        {
+                            "type": "special",
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "color": "red",
+                                    "text": "DOWN"
+                                }
+                            }
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "red",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center"
+            }
+        },
+        {
+            "id": 13,
+            "title": "Node 3 — watchdog.service",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 8,
+                "y": 28
+            },
+            "targets": [
+                {
+                    "expr": "node_systemd_unit_state{instance=\"10.0.0.3:9100\",name=\"watchdog.service\",state=\"active\"}",
+                    "legendFormat": "node-3",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "type": "value",
+                            "options": {
+                                "1": {
+                                    "color": "green",
+                                    "text": "ACTIVE"
+                                }
+                            }
+                        },
+                        {
+                            "type": "special",
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "color": "red",
+                                    "text": "DOWN"
+                                }
+                            }
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "red",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center"
+            }
+        },
+        {
+            "id": 14,
+            "title": "Pingable but NotReady (freeze signal)",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 8,
+                "x": 12,
+                "y": 28
+            },
+            "targets": [
+                {
+                    "expr": "sum((kube_node_status_condition{condition=\"Ready\",status=\"true\",node=\"node-1.eldertree.local\"} == 0 and up{instance=\"10.0.0.1:9100\"} == 1) or (kube_node_status_condition{condition=\"Ready\",status=\"true\",node=\"node-2.eldertree.local\"} == 0 and up{instance=\"10.0.0.2:9100\"} == 1) or (kube_node_status_condition{condition=\"Ready\",status=\"true\",node=\"node-3.eldertree.local\"} == 0 and up{instance=\"10.0.0.3:9100\"} == 1))",
+                    "legendFormat": "nodes",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "type": "value",
+                            "options": {
+                                "0": {
+                                    "color": "green",
+                                    "text": "OK"
+                                }
+                            }
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "textMode": "value_and_name"
+            }
+        },
+        {
+            "id": 15,
+            "title": "OOM kills (5m increase)",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 20,
+                "y": 28
+            },
+            "targets": [
+                {
+                    "expr": "sum(increase(node_vmstat_oom_kill[5m]))",
+                    "legendFormat": "kills",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center"
+            }
+        },
+        {
+            "id": 16,
+            "title": "Node uptime",
+            "type": "timeseries",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 32
+            },
+            "targets": [
+                {
+                    "expr": "time() - node_boot_time_seconds{instance=~\"10.0.0.[1-3]:9100\"}",
+                    "legendFormat": "{{instance}}"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "dtdurations"
+                }
+            }
+        },
+        {
+            "id": 17,
+            "title": "Reboot events (10m)",
+            "type": "timeseries",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 32
+            },
+            "targets": [
+                {
+                    "expr": "changes(node_boot_time_seconds{instance=~\"10.0.0.[1-3]:9100\"}[10m])",
+                    "legendFormat": "{{instance}}"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "drawStyle": "bars",
+                        "fillOpacity": 80
+                    },
+                    "min": 0,
+                    "max": 2
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Hardware health** (`/d/hardware-health`): per-node `watchdog.service` status, freeze signal (exporter up + NotReady), OOM kills, node uptime, reboot events — matches `WatchdogServiceDown`, `NodePingableButNotReady`, `NodeUnexpectedReboot`, `NodeOOMKill` alerts.
- **Ops home** (`/d/eldertree-ops-home`): Pi node summary row + link to Hardware health.
- Bump **monitoring-stack** chart **0.2.11**.

## Test plan

- [ ] `flux reconcile helmrelease monitoring-stack -n observability --force` (or wait for GitOps)
- [ ] Open https://grafana.eldertree.local/d/hardware-health — watchdog stats green on all 3 nodes
- [ ] Open https://grafana.eldertree.local/d/eldertree-ops-home — Pi row shows 3 Ready, 3 watchdog active, freeze OK


Made with [Cursor](https://cursor.com)