### PR TITLE
feat: ElderTree project hub and quick-open script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
+- **ElderTree project hub** — [`docs/ELDERTREE.md`](docs/ELDERTREE.md), [`scripts/operations/eldertree-open.sh`](scripts/operations/eldertree-open.sh), updated [`clusters/eldertree/README.md`](clusters/eldertree/README.md).
 - **InfraOPS & o11y standards** — Agent [`eldertree-infraops`](.claude/agents/eldertree-infraops.md); [`docs/ONBOARDING_APP_OBSERVABILITY.md`](docs/ONBOARDING_APP_OBSERVABILITY.md); workspace [`OBSERVABILITY_STANDARDS.md`](../workspace-config/docs/OBSERVABILITY_STANDARDS.md) (DRY monitoring checklist).
 - **Hardware** — [`docs/HARDWARE_CHASSIS.md`](docs/HARDWARE_CHASSIS.md) links mechanical CAD to [eldertree-chassis](https://github.com/raolivei/eldertree-chassis); README hardware section updated.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ K3s cluster on Raspberry Pi, managed with Ansible and Terraform.
 - Raspberry Pi 5 (8GB, ARM64)
 - Debian 12 Bookworm
 - Physical tower (CAD / BOM): [**eldertree-chassis**](https://github.com/raolivei/eldertree-chassis) — [docs/HARDWARE_CHASSIS.md](docs/HARDWARE_CHASSIS.md)
+- **Project hub:** [docs/ELDERTREE.md](docs/ELDERTREE.md) · Grafana [ops home](https://grafana.eldertree.local/d/eldertree-ops-home) · `./scripts/operations/eldertree-open.sh`
 
 ## Cluster Nodes
 

--- a/clusters/eldertree/README.md
+++ b/clusters/eldertree/README.md
@@ -1,22 +1,30 @@
-# Eldertree Cluster
+# Eldertree cluster (K3s)
 
-K3s control plane with embedded etcd.
+3-node HA control plane on Raspberry Pi 5. GitOps path: `clusters/eldertree/`.
 
-## Status
+## See the project
 
-✅ Control plane ready (eldertree)
+| Resource | Link |
+|----------|------|
+| **Project hub** | [docs/ELDERTREE.md](../../docs/ELDERTREE.md) |
+| **Live dashboards** | https://grafana.eldertree.local/d/eldertree-ops-home |
+| **Docs site** | https://docs.eldertree.xyz/project |
+| **Quick open** | `../../scripts/operations/eldertree-open.sh` |
 
-## Deploy Apps
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+kubectl get nodes
+```
+
+## Deploy apps
 
 ```bash
 export KUBECONFIG=~/.kube/config-eldertree
 kubectl apply -f your-app.yaml
 ```
 
-## Add Workers
+Flux reconciles manifests under this directory on the cluster.
 
-```bash
-cat ../../ansible/k3s-node-token
-# On worker (fleet-worker-01, fleet-worker-02, etc.):
-# curl -sfL https://get.k3s.io | K3S_URL=https://eldertree:6443 K3S_TOKEN=<token> sh -
-```
+## Physical hardware
+
+Portable tower CAD: [eldertree-chassis](https://github.com/raolivei/eldertree-chassis) · [HARDWARE_CHASSIS.md](../../docs/HARDWARE_CHASSIS.md)

--- a/docs/ELDERTREE.md
+++ b/docs/ELDERTREE.md
@@ -1,0 +1,94 @@
+# ElderTree cluster — project hub
+
+Single map for the **eldertree** edge cluster: hardware, software repos, live dashboards, and docs.
+
+## See it live
+
+| What | URL / command |
+|------|----------------|
+| **Ops home (Grafana)** | https://grafana.eldertree.local/d/eldertree-ops-home |
+| **Cluster overview** | https://grafana.eldertree.local/d/eldertree-cluster |
+| **Hardware health (Pis)** | https://grafana.eldertree.local/d/hardware-health |
+| **Runbook + project page** | https://docs.eldertree.xyz/project |
+| **Open dashboards + status** | `./scripts/operations/eldertree-open.sh` |
+
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+kubectl get nodes -o wide
+kubectl get pods -A | grep -v Running | grep -v Completed || true
+```
+
+## Repositories
+
+| Repo | Role |
+|------|------|
+| [pi-fleet](https://github.com/raolivei/pi-fleet) | K3s, Ansible, Terraform, FluxCD, monitoring |
+| [eldertree-chassis](https://github.com/raolivei/eldertree-chassis) | OpenSCAD tower, BOM, prints (private) |
+| [eldertree-docs](https://github.com/raolivei/eldertree-docs) | Runbook (public + local) |
+
+## Physical + compute
+
+See [HARDWARE_CHASSIS.md](HARDWARE_CHASSIS.md) and [eldertree-chassis](https://github.com/raolivei/eldertree-chassis).
+
+| Layer | Component |
+|-------|-----------|
+| Base | EcoFlow River 3 |
+| Network | TP-Link TL-SG1008MP (PoE+) |
+| Nodes | 3× Pi 5 (8GB), NVMe + PoE+ HAT |
+
+## Nodes
+
+| Node | wlan0 | eth0 (cluster) | Hostname |
+|------|-------|----------------|----------|
+| node-1 | 192.168.2.101 | 10.0.0.1 | node-1.eldertree.local |
+| node-2 | 192.168.2.102 | 10.0.0.2 | node-2.eldertree.local |
+| node-3 | 192.168.2.103 | 10.0.0.3 | node-3.eldertree.local |
+
+**VIP:** API `192.168.2.100` · Ingress `192.168.2.200` · DNS `192.168.2.201`
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph physical [Physical tower]
+    UPS[EcoFlow River 3]
+    SW[TL-SG1008MP PoE+]
+    Pi1[Pi node-1]
+    Pi2[Pi node-2]
+    Pi3[Pi node-3]
+    UPS --> SW
+    SW --> Pi1 & Pi2 & Pi3
+  end
+
+  subgraph k8s [K3s HA]
+    VIP[kube-vip 192.168.2.100]
+    Pi1 & Pi2 & Pi3 --> VIP
+    Apps[Apps: canopy swimto openclaw ...]
+    VIP --> Apps
+  end
+
+  subgraph observe [Observability]
+    Graf[Grafana]
+    Prom[Prometheus]
+    Apps --> Prom --> Graf
+  end
+```
+
+## Key local services
+
+| Service | URL |
+|---------|-----|
+| Grafana | https://grafana.eldertree.local |
+| Prometheus | https://prometheus.eldertree.local |
+| Vault | https://vault.eldertree.local |
+| Pi-hole | https://pihole.eldertree.local |
+| OpenClaw | https://openclaw.eldertree.local |
+
+Full service list: [clusters/eldertree/openclaw/docs/ELDERTREE_KNOWLEDGE.md](../clusters/eldertree/openclaw/docs/ELDERTREE_KNOWLEDGE.md).
+
+## More reading
+
+- [NETWORK.md](../NETWORK.md) — IPs and VIPs
+- [GIGABIT_NETWORK_SETUP.md](GIGABIT_NETWORK_SETUP.md) — eth0 isolated switch
+- [helm/monitoring-stack/DASHBOARDS.md](../helm/monitoring-stack/DASHBOARDS.md) — Grafana UIDs
+- [runbook: chassis assembly](https://docs.eldertree.xyz/runbook/hardware/chassis)

--- a/scripts/operations/eldertree-open.sh
+++ b/scripts/operations/eldertree-open.sh
@@ -14,8 +14,7 @@ echo ""
 
 if command -v kubectl >/dev/null 2>&1; then
   if kubectl cluster-info >/dev/null 2>&1; then
-    kubectl get nodes -o custom-columns=NAME:.metadata.name,READY:.status.conditions[-1].type,STATUS:.status.conditions[-1].status,INTERNAL-IP:.status.addresses[?(@.type==\"InternalIP\")].address 2>/dev/null \
-      | head -10 || kubectl get nodes
+    kubectl get nodes -o wide 2>/dev/null || kubectl get nodes
     echo ""
     not_ready="$(kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | wc -l | tr -d ' ')"
     echo "Pods not Running/Succeeded: ${not_ready}"

--- a/scripts/operations/eldertree-open.sh
+++ b/scripts/operations/eldertree-open.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Open ElderTree project views: Grafana ops home, docs project page, optional kubectl status.
+set -euo pipefail
+
+export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config-eldertree}"
+
+OPEN_BROWSER="${OPEN_BROWSER:-1}"
+DOCS_URL="${ELDERTREE_DOCS_URL:-https://docs.eldertree.xyz/project}"
+GRAFANA_URL="${ELDERTREE_GRAFANA_URL:-https://grafana.eldertree.local/d/eldertree-ops-home}"
+
+echo "=== ElderTree cluster ==="
+echo "KUBECONFIG=${KUBECONFIG}"
+echo ""
+
+if command -v kubectl >/dev/null 2>&1; then
+  if kubectl cluster-info >/dev/null 2>&1; then
+    kubectl get nodes -o custom-columns=NAME:.metadata.name,READY:.status.conditions[-1].type,STATUS:.status.conditions[-1].status,INTERNAL-IP:.status.addresses[?(@.type==\"InternalIP\")].address 2>/dev/null \
+      | head -10 || kubectl get nodes
+    echo ""
+    not_ready="$(kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | wc -l | tr -d ' ')"
+    echo "Pods not Running/Succeeded: ${not_ready}"
+  else
+    echo "(kubectl: cluster unreachable — check VPN / LAN / KUBECONFIG)"
+  fi
+else
+  echo "(kubectl not installed)"
+fi
+
+echo ""
+echo "Links:"
+echo "  Grafana ops home: ${GRAFANA_URL}"
+echo "  Project hub:      ${DOCS_URL}"
+echo "  pi-fleet hub:     docs/ELDERTREE.md"
+echo ""
+
+if [[ "${OPEN_BROWSER}" == "1" ]] && command -v open >/dev/null 2>&1; then
+  open "${GRAFANA_URL}" 2>/dev/null || true
+  open "${DOCS_URL}" 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary
- `docs/ELDERTREE.md` — single map: nodes, repos, Grafana, architecture
- `scripts/operations/eldertree-open.sh` — kubectl status + open Grafana + docs project page
- `clusters/eldertree/README.md` — points to hub

Pairs with eldertree-docs `/project` page (separate PR).

## Test plan
- [ ] `./scripts/operations/eldertree-open.sh` on LAN
- [ ] https://docs.eldertree.xyz/project after docs PR merges

Made with [Cursor](https://cursor.com)