### PR TITLE
chore: Dependabot secret sync from Vault + CI docs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,3 +1,6 @@
+# Terraform secrets: source of truth is Vault (secret/pi-fleet/terraform/*).
+# GitHub-hosted runners cannot reach vault.eldertree.local — repo secrets are synced via:
+#   ./scripts/sync-github-terraform-secrets-from-vault.sh --app actions --app dependabot
 name: "Terraform"
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
-- **Scripts** — [`sync-github-terraform-secrets-from-vault.sh`](scripts/sync-github-terraform-secrets-from-vault.sh) pushes Terraform CI secrets from Vault to GitHub Dependabot; documents `secret/pi-fleet/terraform/terraform-cloud-token` for `TF_API_TOKEN`.
+- **Vault-first Terraform secrets** — [`docs/VAULT_TERRAFORM_SECRETS.md`](docs/VAULT_TERRAFORM_SECRETS.md); [`scripts/lib/load-terraform-secrets-from-vault.sh`](scripts/lib/load-terraform-secrets-from-vault.sh); [`setup-terraform-cloud-token.sh`](scripts/setup-terraform-cloud-token.sh); ExternalSecret `pi-fleet-terraform-vault-credentials`; `run-terraform.sh` loads HCP token from Vault.
+- **Scripts** — [`sync-github-terraform-secrets-from-vault.sh`](scripts/sync-github-terraform-secrets-from-vault.sh) publishes Vault → GitHub Actions/Dependabot (CI cache).
 - **ElderTree project hub** — [`docs/ELDERTREE.md`](docs/ELDERTREE.md), [`scripts/operations/eldertree-open.sh`](scripts/operations/eldertree-open.sh), updated [`clusters/eldertree/README.md`](clusters/eldertree/README.md).
 - **InfraOPS & o11y standards** — Agent [`eldertree-infraops`](.claude/agents/eldertree-infraops.md); [`docs/ONBOARDING_APP_OBSERVABILITY.md`](docs/ONBOARDING_APP_OBSERVABILITY.md); workspace [`OBSERVABILITY_STANDARDS.md`](../workspace-config/docs/OBSERVABILITY_STANDARDS.md) (DRY monitoring checklist).
 - **Hardware** — [`docs/HARDWARE_CHASSIS.md`](docs/HARDWARE_CHASSIS.md) links mechanical CAD to [eldertree-chassis](https://github.com/raolivei/eldertree-chassis); README hardware section updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 - **Grafana (monitoring-stack 0.2.11)** — `hardware-health` and `eldertree-ops-home` panels for watchdog, freeze signal, OOM, and node uptime/reboot (metrics behind `WatchdogServiceDown`, `NodePingableButNotReady`, `NodeUnexpectedReboot`).
 
+### Changed
+
+- **HCP token Vault path** — active secret at `secret/pi-fleet/terraform/eldertree-github-2026` (`token`); loaders and ExternalSecret read this path (fallback: `terraform-cloud-token`).
+
 ### Added
 
 - **Vault-first Terraform secrets** — [`docs/VAULT_TERRAFORM_SECRETS.md`](docs/VAULT_TERRAFORM_SECRETS.md); [`scripts/lib/load-terraform-secrets-from-vault.sh`](scripts/lib/load-terraform-secrets-from-vault.sh); [`setup-terraform-cloud-token.sh`](scripts/setup-terraform-cloud-token.sh); ExternalSecret `pi-fleet-terraform-vault-credentials`; `run-terraform.sh` loads HCP token from Vault.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
+- **Scripts** — [`sync-github-terraform-secrets-from-vault.sh`](scripts/sync-github-terraform-secrets-from-vault.sh) pushes Terraform CI secrets from Vault to GitHub Dependabot; documents `secret/pi-fleet/terraform/terraform-cloud-token` for `TF_API_TOKEN`.
 - **ElderTree project hub** — [`docs/ELDERTREE.md`](docs/ELDERTREE.md), [`scripts/operations/eldertree-open.sh`](scripts/operations/eldertree-open.sh), updated [`clusters/eldertree/README.md`](clusters/eldertree/README.md).
 - **InfraOPS & o11y standards** — Agent [`eldertree-infraops`](.claude/agents/eldertree-infraops.md); [`docs/ONBOARDING_APP_OBSERVABILITY.md`](docs/ONBOARDING_APP_OBSERVABILITY.md); workspace [`OBSERVABILITY_STANDARDS.md`](../workspace-config/docs/OBSERVABILITY_STANDARDS.md) (DRY monitoring checklist).
 - **Hardware** — [`docs/HARDWARE_CHASSIS.md`](docs/HARDWARE_CHASSIS.md) links mechanical CAD to [eldertree-chassis](https://github.com/raolivei/eldertree-chassis); README hardware section updated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,14 @@ git fetch --prune origin               # drop stale remote-tracking refs
 
 Org-wide convention: [workspace-config/docs/PROJECT_CONVENTIONS.md](../workspace-config/docs/PROJECT_CONVENTIONS.md#github-pull-request-branch-cleanup).
 
+### GitHub Actions and Dependabot
+
+- **`main` Terraform** ([`terraform.yml`](.github/workflows/terraform.yml)) should stay green — badge on [README](README.md).
+- **Dependabot PRs** do not receive Actions secrets. After rotating Cloudflare or Terraform Cloud credentials:
+  1. Update Vault (`secret/pi-fleet/terraform/*`) and/or GitHub Actions secrets.
+  2. Run `./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot` (Cloudflare from Vault; pass `TF_API_TOKEN=…` for Terraform Cloud — not stored in Vault by default).
+- A red Terraform check on an old Dependabot PR that was **merged anyway** (e.g. `actions/checkout` bump) is safe to ignore if **`main` is green**.
+
 ### Commit Message Convention
 
 Follow conventional commits format:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,14 @@ Org-wide convention: [workspace-config/docs/PROJECT_CONVENTIONS.md](../workspace
 
 ### GitHub Actions and Dependabot
 
+- **Vault is the source of truth** for Terraform credentials — see [`docs/VAULT_TERRAFORM_SECRETS.md`](docs/VAULT_TERRAFORM_SECRETS.md).
+- **Local / cluster apps** read Vault via `./terraform/run-terraform.sh` or ExternalSecret `pi-fleet-terraform-vault-credentials`.
+- **GitHub-hosted CI** cannot reach `vault.eldertree.local`; after Vault changes run:
+  ```bash
+  ./scripts/sync-github-terraform-secrets-from-vault.sh --app actions --app dependabot
+  ```
+- **New HCP token:** `./scripts/setup-terraform-cloud-token.sh --sync-github` (create token at [HCP API tokens](https://app.terraform.io/app/settings/tokens) first).
 - **`main` Terraform** ([`terraform.yml`](.github/workflows/terraform.yml)) should stay green — badge on [README](README.md).
-- **Dependabot PRs** do not receive Actions secrets. After rotating Cloudflare or Terraform Cloud credentials:
-  1. Update Vault (`secret/pi-fleet/terraform/*`) and/or GitHub Actions secrets.
-  2. Run `./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot` (Cloudflare from Vault; pass `TF_API_TOKEN=…` for Terraform Cloud — not stored in Vault by default).
-- A red Terraform check on an old Dependabot PR that was **merged anyway** (e.g. `actions/checkout` bump) is safe to ignore if **`main` is green**.
 
 ### Commit Message Convention
 

--- a/VAULT.md
+++ b/VAULT.md
@@ -119,7 +119,7 @@ kubectl exec -n vault vault-0 -- sh -c "export VAULT_ADDR=http://127.0.0.1:8200 
 All infrastructure secrets are organized under `secret/pi-fleet/`:
 - `secret/pi-fleet/terraform/cloudflare-api-token` - Cloudflare API token for Terraform DNS management (`api-token`)
 - `secret/pi-fleet/terraform/cloudflare-origin-ca-key` - Cloudflare Origin CA key (`origin-ca-key`)
-- `secret/pi-fleet/terraform/terraform-cloud-token` - HCP Terraform API token for CI (`token`; optional — GitHub Actions `TF_API_TOKEN` is often the source of truth)
+- `secret/pi-fleet/terraform/terraform-cloud-token` - HCP Terraform API token (`token`) — **source of truth**; sync to GitHub with `scripts/sync-github-terraform-secrets-from-vault.sh` (see [`docs/VAULT_TERRAFORM_SECRETS.md`](docs/VAULT_TERRAFORM_SECRETS.md))
 - `secret/pi-fleet/external-dns/cloudflare-api-token` - Cloudflare API token for External-DNS Cloudflare provider (`api-token`)
 - `secret/pi-fleet/cloudflare-tunnel/token` - Cloudflare Tunnel token for cloudflared connector (`token`)
 - `secret/pi-fleet/terraform/pi-user` - Pi SSH username (optional, defaults to "pi") (`pi-user`)

--- a/VAULT.md
+++ b/VAULT.md
@@ -118,6 +118,8 @@ kubectl exec -n vault vault-0 -- sh -c "export VAULT_ADDR=http://127.0.0.1:8200 
 ### Infrastructure (pi-fleet)
 All infrastructure secrets are organized under `secret/pi-fleet/`:
 - `secret/pi-fleet/terraform/cloudflare-api-token` - Cloudflare API token for Terraform DNS management (`api-token`)
+- `secret/pi-fleet/terraform/cloudflare-origin-ca-key` - Cloudflare Origin CA key (`origin-ca-key`)
+- `secret/pi-fleet/terraform/terraform-cloud-token` - HCP Terraform API token for CI (`token`; optional — GitHub Actions `TF_API_TOKEN` is often the source of truth)
 - `secret/pi-fleet/external-dns/cloudflare-api-token` - Cloudflare API token for External-DNS Cloudflare provider (`api-token`)
 - `secret/pi-fleet/cloudflare-tunnel/token` - Cloudflare Tunnel token for cloudflared connector (`token`)
 - `secret/pi-fleet/terraform/pi-user` - Pi SSH username (optional, defaults to "pi") (`pi-user`)

--- a/VAULT.md
+++ b/VAULT.md
@@ -119,7 +119,7 @@ kubectl exec -n vault vault-0 -- sh -c "export VAULT_ADDR=http://127.0.0.1:8200 
 All infrastructure secrets are organized under `secret/pi-fleet/`:
 - `secret/pi-fleet/terraform/cloudflare-api-token` - Cloudflare API token for Terraform DNS management (`api-token`)
 - `secret/pi-fleet/terraform/cloudflare-origin-ca-key` - Cloudflare Origin CA key (`origin-ca-key`)
-- `secret/pi-fleet/terraform/terraform-cloud-token` - HCP Terraform API token (`token`) — **source of truth**; sync to GitHub with `scripts/sync-github-terraform-secrets-from-vault.sh` (see [`docs/VAULT_TERRAFORM_SECRETS.md`](docs/VAULT_TERRAFORM_SECRETS.md))
+- `secret/pi-fleet/terraform/eldertree-github-2026` - HCP Terraform API token (`token`) — **source of truth**; sync to GitHub with `scripts/sync-github-terraform-secrets-from-vault.sh` (see [`docs/VAULT_TERRAFORM_SECRETS.md`](docs/VAULT_TERRAFORM_SECRETS.md))
 - `secret/pi-fleet/external-dns/cloudflare-api-token` - Cloudflare API token for External-DNS Cloudflare provider (`api-token`)
 - `secret/pi-fleet/cloudflare-tunnel/token` - Cloudflare Tunnel token for cloudflared connector (`token`)
 - `secret/pi-fleet/terraform/pi-user` - Pi SSH username (optional, defaults to "pi") (`pi-user`)

--- a/clusters/eldertree/secrets-management/external-secrets/externalsecrets/kustomization.yaml
+++ b/clusters/eldertree/secrets-management/external-secrets/externalsecrets/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   # - journey-secrets.yaml # DISABLED - journey namespace not created (journey app disabled)
   - external-dns-tsig-secret.yaml
   - external-dns-cloudflare-secret.yaml
+  - terraform-vault-credentials.yaml
   # Note: nima-secrets.yaml not included as NIMA has no secrets currently
   # When secrets are needed, uncomment and add data section
 

--- a/clusters/eldertree/secrets-management/external-secrets/externalsecrets/terraform-vault-credentials.yaml
+++ b/clusters/eldertree/secrets-management/external-secrets/externalsecrets/terraform-vault-credentials.yaml
@@ -1,0 +1,32 @@
+# Sync pi-fleet Terraform credentials from Vault for in-cluster consumers (operators, future automation).
+# GitHub-hosted Actions cannot reach vault.eldertree.local — use scripts/sync-github-terraform-secrets-from-vault.sh.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pi-fleet-terraform-vault-credentials
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: pi-fleet-terraform-vault-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: cloudflare-api-token
+      remoteRef:
+        key: secret/pi-fleet/terraform/cloudflare-api-token
+        property: api-token
+    - secretKey: cloudflare-origin-ca-key
+      remoteRef:
+        key: secret/pi-fleet/terraform/cloudflare-origin-ca-key
+        property: origin-ca-key
+    - secretKey: terraform-cloud-token
+      remoteRef:
+        key: secret/pi-fleet/terraform/terraform-cloud-token
+        property: token
+    - secretKey: pi-user
+      remoteRef:
+        key: secret/pi-fleet/terraform/pi-user
+        property: pi-user

--- a/clusters/eldertree/secrets-management/external-secrets/externalsecrets/terraform-vault-credentials.yaml
+++ b/clusters/eldertree/secrets-management/external-secrets/externalsecrets/terraform-vault-credentials.yaml
@@ -24,7 +24,7 @@ spec:
         property: origin-ca-key
     - secretKey: terraform-cloud-token
       remoteRef:
-        key: secret/pi-fleet/terraform/terraform-cloud-token
+        key: secret/pi-fleet/terraform/eldertree-github-2026
         property: token
     - secretKey: pi-user
       remoteRef:

--- a/docs/VAULT_SECRETS_BOOTSTRAP.md
+++ b/docs/VAULT_SECRETS_BOOTSTRAP.md
@@ -17,6 +17,8 @@ This document lists all secrets required for the eldertree cluster to function p
 | `secret/pi-fleet/external-dns/cloudflare-api-token` | `api-token` | Cloudflare API token for DNS | [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens) - needs Zone:DNS:Edit |
 | `secret/pi-fleet/external-dns/tsig-secret` | `secret` | TSIG key for RFC2136 DNS | Generate: `openssl rand -base64 32` |
 | `secret/pi-fleet/terraform/cloudflare-api-token` | `api-token` | Cloudflare API token for Terraform | Same as above or separate token |
+| `secret/pi-fleet/terraform/cloudflare-origin-ca-key` | `origin-ca-key` | Cloudflare Origin CA key for Terraform | Cloudflare dashboard → Origin Server |
+| `secret/pi-fleet/terraform/terraform-cloud-token` | `token` | HCP Terraform / Terraform Cloud API token (`TF_API_TOKEN` in GitHub Actions) | [app.terraform.io](https://app.terraform.io/app/settings/tokens) — optional in Vault; Actions secret is source of truth today |
 
 ### Application Secrets
 

--- a/docs/VAULT_TERRAFORM_SECRETS.md
+++ b/docs/VAULT_TERRAFORM_SECRETS.md
@@ -6,7 +6,8 @@ Vault is the **source of truth** for Terraform and HCP Terraform credentials. Ap
 
 | Vault path | Key | Used for |
 |------------|-----|----------|
-| `secret/pi-fleet/terraform/terraform-cloud-token` | `token` | HCP Terraform (`TF_TOKEN_app_terraform_io` / `TF_API_TOKEN`) |
+| `secret/pi-fleet/terraform/eldertree-github-2026` | `token` | HCP Terraform (`TF_TOKEN_app_terraform_io` / `TF_API_TOKEN`) — active |
+| `secret/pi-fleet/terraform/terraform-cloud-token` | `token` | Legacy alias (loader falls back if present) |
 | `secret/pi-fleet/terraform/cloudflare-api-token` | `api-token` | Cloudflare provider |
 | `secret/pi-fleet/terraform/cloudflare-origin-ca-key` | `origin-ca-key` | Origin CA certificates |
 | `secret/pi-fleet/terraform/pi-user` | `pi-user` | Optional SSH user for k3s resources |

--- a/docs/VAULT_TERRAFORM_SECRETS.md
+++ b/docs/VAULT_TERRAFORM_SECRETS.md
@@ -1,0 +1,48 @@
+# Terraform secrets in Vault
+
+Vault is the **source of truth** for Terraform and HCP Terraform credentials. Applications read from Vault; GitHub Actions and Dependabot use **synced copies** in repository secrets.
+
+## Paths (KV v2)
+
+| Vault path | Key | Used for |
+|------------|-----|----------|
+| `secret/pi-fleet/terraform/terraform-cloud-token` | `token` | HCP Terraform (`TF_TOKEN_app_terraform_io` / `TF_API_TOKEN`) |
+| `secret/pi-fleet/terraform/cloudflare-api-token` | `api-token` | Cloudflare provider |
+| `secret/pi-fleet/terraform/cloudflare-origin-ca-key` | `origin-ca-key` | Origin CA certificates |
+| `secret/pi-fleet/terraform/pi-user` | `pi-user` | Optional SSH user for k3s resources |
+
+## Who reads Vault directly
+
+| Consumer | How |
+|----------|-----|
+| **Local Terraform** | `./terraform/run-terraform.sh` or `source scripts/lib/load-terraform-secrets-from-vault.sh` |
+| **Scripts** | `./scripts/get-vault-secret.sh secret/pi-fleet/terraform/...` |
+| **Kubernetes** | ExternalSecret `pi-fleet-terraform-vault-credentials` in `external-secrets` namespace |
+| **External-DNS** | Separate path `secret/pi-fleet/external-dns/cloudflare-api-token` (may match terraform token) |
+
+## GitHub Actions and Dependabot
+
+Runners on `ubuntu-latest` **cannot** reach `https://vault.eldertree.local`. After any Vault change:
+
+```bash
+./scripts/sync-github-terraform-secrets-from-vault.sh --app actions --app dependabot
+```
+
+Requires `kubectl` + unsealed Vault + `gh auth login`.
+
+## Bootstrap a new HCP token
+
+You cannot read an existing token back from HCP or GitHub. Create a new user token at [app.terraform.io/app/settings/tokens](https://app.terraform.io/app/settings/tokens), then:
+
+```bash
+./scripts/setup-terraform-cloud-token.sh --sync-github
+```
+
+That stores in Vault, updates `~/.terraform.d/credentials.tfrc.json`, and publishes to GitHub.
+
+## Verify
+
+```bash
+./scripts/lib/load-terraform-secrets-from-vault.sh
+cd terraform && ./run-terraform.sh plan
+```

--- a/scripts/get-vault-secret.sh
+++ b/scripts/get-vault-secret.sh
@@ -41,10 +41,13 @@ if ! kubectl exec -n "$VAULT_NAMESPACE" "$VAULT_POD" -- vault status > /dev/null
     exit 1
 fi
 
+# Prefer ESO root token (works when /tmp/vault-init.json is absent in the pod)
+VAULT_TOKEN=$(kubectl get secret vault-token -n external-secrets -o jsonpath='{.data.token}' 2>/dev/null | base64 -d || true)
+
 # Get secret from Vault
 SECRET_VALUE=$(kubectl exec -n "$VAULT_NAMESPACE" "$VAULT_POD" -- \
-    sh -c "export VAULT_ADDR=http://127.0.0.1:8200 && export VAULT_TOKEN=\$(cat /tmp/vault-init.json 2>/dev/null | jq -r '.root_token' || echo '') && \
-    vault kv get -format=json \"$SECRET_PATH\" 2>/dev/null | jq -r \".data.data.$KEY_NAME\" || echo ''" 2>/dev/null)
+    env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${VAULT_TOKEN}" \
+    vault kv get "-field=${KEY_NAME}" "$SECRET_PATH" 2>/dev/null || true)
 
 if [ -z "$SECRET_VALUE" ] || [ "$SECRET_VALUE" = "null" ]; then
     echo "❌ Secret not found at $SECRET_PATH with key $KEY_NAME" >&2

--- a/scripts/lib/load-terraform-secrets-from-vault.sh
+++ b/scripts/lib/load-terraform-secrets-from-vault.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Load Terraform-related secrets from Vault (KV v2) into the environment.
+# Source this file:  source "$(dirname "$0")/../lib/load-terraform-secrets-from-vault.sh"
+#
+# Sets (when present in Vault):
+#   TF_VAR_cloudflare_api_token, TF_VAR_cloudflare_origin_ca_key, TF_VAR_pi_user
+#   TF_TOKEN_app_terraform_io  (HCP Terraform / Terraform Cloud)
+#
+# Paths:
+#   secret/pi-fleet/terraform/cloudflare-api-token     (api-token)
+#   secret/pi-fleet/terraform/cloudflare-origin-ca-key (origin-ca-key)
+#   secret/pi-fleet/terraform/terraform-cloud-token    (token)
+#   secret/pi-fleet/terraform/pi-user                    (pi-user)
+
+load_terraform_secrets_from_vault() {
+  export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
+
+  local script_dir vault_pod vault_token
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  _vault_field() {
+    local path="$1" field="$2"
+    if command -v kubectl >/dev/null 2>&1; then
+      vault_pod=$(kubectl get pods -n vault -l app.kubernetes.io/name=vault \
+        -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null | awk '{print $1}')
+      if [[ -n "$vault_pod" ]]; then
+        vault_token=$(kubectl get secret vault-token -n external-secrets \
+          -o jsonpath='{.data.token}' 2>/dev/null | base64 -d)
+        if [[ -n "$vault_token" ]]; then
+          kubectl exec -n vault "$vault_pod" -- \
+            env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${vault_token}" \
+            vault kv get "-field=${field}" "$path" 2>/dev/null || true
+          return
+        fi
+      fi
+    fi
+    # Fallback: get-vault-secret.sh (same paths)
+    if [[ -f "${script_dir}/../get-vault-secret.sh" ]]; then
+      "${script_dir}/../get-vault-secret.sh" "$path" "$field" 2>/dev/null || true
+    fi
+  }
+
+  local v
+  v=$(_vault_field secret/pi-fleet/terraform/cloudflare-api-token api-token)
+  [[ -n "$v" ]] && export TF_VAR_cloudflare_api_token="$v"
+
+  v=$(_vault_field secret/pi-fleet/terraform/cloudflare-origin-ca-key origin-ca-key)
+  [[ -n "$v" ]] && export TF_VAR_cloudflare_origin_ca_key="$v"
+
+  v=$(_vault_field secret/pi-fleet/terraform/terraform-cloud-token token)
+  [[ -n "$v" ]] && export TF_TOKEN_app_terraform_io="$v"
+
+  v=$(_vault_field secret/pi-fleet/terraform/pi-user pi-user)
+  [[ -n "$v" ]] && export TF_VAR_pi_user="$v"
+}
+
+# When executed directly, print which keys are set (not values)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  load_terraform_secrets_from_vault
+  for name in TF_VAR_cloudflare_api_token TF_VAR_cloudflare_origin_ca_key TF_TOKEN_app_terraform_io TF_VAR_pi_user; do
+    if [[ -n "${!name:-}" ]]; then
+      echo "set $name"
+    else
+      echo "missing $name"
+    fi
+  done
+fi

--- a/scripts/lib/load-terraform-secrets-from-vault.sh
+++ b/scripts/lib/load-terraform-secrets-from-vault.sh
@@ -9,7 +9,8 @@
 # Paths:
 #   secret/pi-fleet/terraform/cloudflare-api-token     (api-token)
 #   secret/pi-fleet/terraform/cloudflare-origin-ca-key (origin-ca-key)
-#   secret/pi-fleet/terraform/terraform-cloud-token    (token)
+#   secret/pi-fleet/terraform/eldertree-github-2026      (token) — active HCP token
+#   secret/pi-fleet/terraform/terraform-cloud-token    (token) — legacy alias
 #   secret/pi-fleet/terraform/pi-user                    (pi-user)
 
 load_terraform_secrets_from_vault() {
@@ -47,8 +48,15 @@ load_terraform_secrets_from_vault() {
   v=$(_vault_field secret/pi-fleet/terraform/cloudflare-origin-ca-key origin-ca-key)
   [[ -n "$v" ]] && export TF_VAR_cloudflare_origin_ca_key="$v"
 
-  v=$(_vault_field secret/pi-fleet/terraform/terraform-cloud-token token)
-  [[ -n "$v" ]] && export TF_TOKEN_app_terraform_io="$v"
+  for hcp_path in \
+    secret/pi-fleet/terraform/eldertree-github-2026 \
+    secret/pi-fleet/terraform/terraform-cloud-token; do
+    v=$(_vault_field "$hcp_path" token)
+    if [[ -n "$v" ]]; then
+      export TF_TOKEN_app_terraform_io="$v"
+      break
+    fi
+  done
 
   v=$(_vault_field secret/pi-fleet/terraform/pi-user pi-user)
   [[ -n "$v" ]] && export TF_VAR_pi_user="$v"

--- a/scripts/setup-terraform-cloud-token.sh
+++ b/scripts/setup-terraform-cloud-token.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ORG="eldertree"
 HOST="app.terraform.io"
-VAULT_PATH="secret/pi-fleet/terraform/terraform-cloud-token"
+VAULT_PATH="${TF_VAULT_HCP_PATH:-secret/pi-fleet/terraform/eldertree-github-2026}"
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
 

--- a/scripts/setup-terraform-cloud-token.sh
+++ b/scripts/setup-terraform-cloud-token.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Store HCP Terraform user API token in Vault (source of truth).
+# Optionally publish to GitHub Actions + Dependabot (public runners cannot read Vault directly).
+#
+# Usage:
+#   ./scripts/setup-terraform-cloud-token.sh              # prompt, Vault only
+#   ./scripts/setup-terraform-cloud-token.sh --sync-github  # Vault + GitHub secrets
+#   TF_API_TOKEN='at-...' ./scripts/setup-terraform-cloud-token.sh --sync-github --no-prompt
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ORG="eldertree"
+HOST="app.terraform.io"
+VAULT_PATH="secret/pi-fleet/terraform/terraform-cloud-token"
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
+
+NO_PROMPT=0
+SYNC_GITHUB=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-prompt) NO_PROMPT=1; shift ;;
+    --sync-github) SYNC_GITHUB=1; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "${TF_API_TOKEN:-}" ]]; then
+  if [[ "$NO_PROMPT" -eq 1 ]]; then
+    echo "Error: set TF_API_TOKEN or run without --no-prompt" >&2
+    exit 1
+  fi
+  echo "Create a token: https://app.terraform.io/app/settings/tokens"
+  echo "Organization: ${ORG}"
+  read -r -s -p "Paste token (hidden): " TF_API_TOKEN
+  echo ""
+  [[ -n "$TF_API_TOKEN" ]] || { echo "Error: empty token" >&2; exit 1; }
+fi
+
+code=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${TF_API_TOKEN}" \
+  -H "Content-Type: application/vnd.api+json" \
+  "https://${HOST}/api/v2/organizations/${ORG}")
+[[ "$code" == "200" ]] || { echo "Error: invalid token for org ${ORG} (HTTP ${code})" >&2; exit 1; }
+
+pod=$(kubectl get pods -n vault -l app.kubernetes.io/name=vault \
+  -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' | awk '{print $1}')
+root=$(kubectl get secret vault-token -n external-secrets -o jsonpath='{.data.token}' | base64 -d)
+[[ -n "$pod" && -n "$root" ]] || { echo "Error: Vault unavailable" >&2; exit 1; }
+
+kubectl exec -n vault "$pod" -- \
+  env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${root}" \
+  vault kv put "$VAULT_PATH" token="${TF_API_TOKEN}" >/dev/null
+
+echo "OK: stored in Vault at ${VAULT_PATH}"
+
+# Local ~/.terraform.d/credentials.tfrc.json
+mkdir -p "${HOME}/.terraform.d"
+python3 - "${HOME}/.terraform.d/credentials.tfrc.json" "$HOST" "$TF_API_TOKEN" <<'PY'
+import json, os, sys
+path, host, token = sys.argv[1], sys.argv[2], sys.argv[3]
+data = {"credentials": {host: {"token": token}}}
+if os.path.isfile(path):
+    with open(path) as f:
+        data = json.load(f)
+    data.setdefault("credentials", {})[host] = {"token": token}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+os.chmod(path, 0o600)
+PY
+echo "OK: ~/.terraform.d/credentials.tfrc.json"
+
+if [[ "$SYNC_GITHUB" -eq 1 ]]; then
+  export TF_API_TOKEN
+  "${SCRIPT_DIR}/sync-github-terraform-secrets-from-vault.sh" --app actions --app dependabot
+else
+  echo ""
+  echo "GitHub Actions/Dependabot cannot reach vault.eldertree.local."
+  echo "After storing in Vault, publish to GitHub with:"
+  echo "  ${SCRIPT_DIR}/sync-github-terraform-secrets-from-vault.sh --app actions --app dependabot"
+fi
+
+echo ""
+echo "Optional: delete the old HCP user token named 'eldertree' after verifying CI."

--- a/scripts/sync-github-terraform-secrets-from-vault.sh
+++ b/scripts/sync-github-terraform-secrets-from-vault.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Sync Terraform workflow secrets from Vault to GitHub (Actions + Dependabot).
+# Publish Terraform CI secrets from Vault → GitHub (Actions + Dependabot).
+# Vault is the source of truth; GitHub secrets are a cache for cloud-hosted runners.
+#
+# Bootstrap HCP token in Vault first: ./scripts/setup-terraform-cloud-token.sh
 #
 # Vault paths (KV v2):
 #   secret/pi-fleet/terraform/cloudflare-api-token     -> api-token
@@ -106,16 +109,12 @@ if [[ -f "$TERRAFORM_DIR/terraform.tfvars" ]]; then
   PUBLIC_IP=$(grep '^public_ip' "$TERRAFORM_DIR/terraform.tfvars" 2>/dev/null | sed -n 's/.*= *"\([^"]*\)".*/\1/p' | head -1 || true)
 fi
 
-if [[ -z "$TF_CLOUD" ]]; then
-  TF_CLOUD="${TF_API_TOKEN:-${TF_TOKEN_app_terraform_io:-}}"
-fi
-
-# Optional: persist Terraform Cloud token in Vault when provided via env
-if [[ -n "$TF_CLOUD" ]]; then
+if [[ -z "$TF_CLOUD" && -n "${TF_API_TOKEN:-}" ]]; then
+  echo "Bootstrap: storing TF_API_TOKEN into Vault..."
   kubectl exec -n vault "$VAULT_POD" -- \
     env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${VAULT_TOKEN}" \
-    vault kv put secret/pi-fleet/terraform/terraform-cloud-token token="${TF_CLOUD}" >/dev/null 2>&1 \
-    && echo "Stored TF token in Vault (secret/pi-fleet/terraform/terraform-cloud-token)" || true
+    vault kv put secret/pi-fleet/terraform/terraform-cloud-token token="${TF_API_TOKEN}" >/dev/null
+  TF_CLOUD="$TF_API_TOKEN"
 fi
 
 if [[ -z "$CF_API" ]]; then
@@ -136,12 +135,11 @@ for app in "${APPS[@]}"; do
 done
 
 if [[ -z "$TF_CLOUD" ]]; then
-  echo "Note: TF_API_TOKEN not in Vault (secret/pi-fleet/terraform/terraform-cloud-token)."
-  echo "      Export TF_API_TOKEN (or TF_TOKEN_app_terraform_io) and re-run this script to sync + store in Vault."
-  echo "      GitHub Actions already has TF_API_TOKEN; Dependabot needs a separate copy:"
-  echo "        TF_API_TOKEN='…' $0 --app dependabot"
-else
-  echo "TF_API_TOKEN synced from Vault."
+  echo "Error: secret/pi-fleet/terraform/terraform-cloud-token missing in Vault." >&2
+  echo "  Run: ./scripts/setup-terraform-cloud-token.sh" >&2
+  exit 1
 fi
+
+echo "Published secrets from Vault to GitHub (${APPS[*]})."
 
 echo "Done."

--- a/scripts/sync-github-terraform-secrets-from-vault.sh
+++ b/scripts/sync-github-terraform-secrets-from-vault.sh
@@ -7,7 +7,7 @@
 # Vault paths (KV v2):
 #   secret/pi-fleet/terraform/cloudflare-api-token     -> api-token
 #   secret/pi-fleet/terraform/cloudflare-origin-ca-key -> origin-ca-key
-#   secret/pi-fleet/terraform/terraform-cloud-token    -> token  (optional; not always in Vault)
+#   secret/pi-fleet/terraform/eldertree-github-2026    -> token  (HCP; falls back to terraform-cloud-token)
 #
 # Usage:
 #   ./scripts/sync-github-terraform-secrets-from-vault.sh
@@ -24,11 +24,10 @@ TERRAFORM_DIR="$REPO_DIR/terraform"
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
 
-APPS=(actions)
+APPS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --app)
-      APPS=()
       shift
       while [[ $# -gt 0 && "$1" != --* ]]; do
         APPS+=("$1")
@@ -45,6 +44,9 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+if [[ ${#APPS[@]} -eq 0 ]]; then
+  APPS=(actions)
+fi
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "Error: gh CLI required" >&2
@@ -97,7 +99,13 @@ echo ""
 
 CF_API=$(vault_field secret/pi-fleet/terraform/cloudflare-api-token api-token)
 CF_ORIGIN=$(vault_field secret/pi-fleet/terraform/cloudflare-origin-ca-key origin-ca-key)
-TF_CLOUD=$(vault_field secret/pi-fleet/terraform/terraform-cloud-token token)
+TF_CLOUD=""
+for hcp_path in \
+  secret/pi-fleet/terraform/eldertree-github-2026 \
+  secret/pi-fleet/terraform/terraform-cloud-token; do
+  TF_CLOUD=$(vault_field "$hcp_path" token)
+  [[ -n "$TF_CLOUD" ]] && break
+done
 PI_USER_VAL=$(vault_field secret/pi-fleet/terraform/pi-user pi-user)
 
 CLOUDFLARE_ZONE_ID=""
@@ -135,7 +143,7 @@ for app in "${APPS[@]}"; do
 done
 
 if [[ -z "$TF_CLOUD" ]]; then
-  echo "Error: secret/pi-fleet/terraform/terraform-cloud-token missing in Vault." >&2
+  echo "Error: HCP token missing in Vault (eldertree-github-2026 or terraform-cloud-token)." >&2
   echo "  Run: ./scripts/setup-terraform-cloud-token.sh" >&2
   exit 1
 fi

--- a/scripts/sync-github-terraform-secrets-from-vault.sh
+++ b/scripts/sync-github-terraform-secrets-from-vault.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Sync Terraform workflow secrets from Vault to GitHub (Actions + Dependabot).
+#
+# Vault paths (KV v2):
+#   secret/pi-fleet/terraform/cloudflare-api-token     -> api-token
+#   secret/pi-fleet/terraform/cloudflare-origin-ca-key -> origin-ca-key
+#   secret/pi-fleet/terraform/terraform-cloud-token    -> token  (optional; not always in Vault)
+#
+# Usage:
+#   ./scripts/sync-github-terraform-secrets-from-vault.sh
+#   ./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot
+#   ./scripts/sync-github-terraform-secrets-from-vault.sh --app actions --app dependabot
+#
+# TF_API_TOKEN: read from Vault when present; else skip (Actions may already have it).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TERRAFORM_DIR="$REPO_DIR/terraform"
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
+
+APPS=(actions)
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APPS=()
+      shift
+      while [[ $# -gt 0 && "$1" != --* ]]; do
+        APPS+=("$1")
+        shift
+      done
+      ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: gh CLI required" >&2
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: gh auth login required" >&2
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+VAULT_POD=$(kubectl get pods -n vault -l app.kubernetes.io/name=vault -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' | awk '{print $1}')
+if [[ -z "$VAULT_POD" ]]; then
+  echo "Error: no running Vault pod" >&2
+  exit 1
+fi
+
+if kubectl exec -n vault "$VAULT_POD" -- vault status -format=json 2>/dev/null | grep -q '"sealed":true'; then
+  echo "Error: Vault is sealed. Run: ./scripts/operations/unseal-vault.sh" >&2
+  exit 1
+fi
+
+VAULT_TOKEN=$(kubectl get secret vault-token -n external-secrets -o jsonpath='{.data.token}' 2>/dev/null | base64 -d)
+if [[ -z "$VAULT_TOKEN" ]]; then
+  echo "Error: secret/external-secrets/vault-token not found" >&2
+  exit 1
+fi
+
+vault_field() {
+  local path="$1" field="$2"
+  kubectl exec -n vault "$VAULT_POD" -- \
+    env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${VAULT_TOKEN}" \
+    vault kv get "-field=${field}" "$path" 2>/dev/null || true
+}
+
+set_gh_secret() {
+  local name="$1" value="$2" app="$3"
+  if [[ -z "$value" ]]; then
+    echo "  skip $name ($app): empty"
+    return 0
+  fi
+  printf '%s' "$value" | gh secret set "$name" --repo "$REPO" --app "$app"
+  echo "  set $name ($app)"
+}
+
+echo "Repository: $REPO"
+echo "Vault pod: $VAULT_POD"
+echo "Targets: ${APPS[*]}"
+echo ""
+
+CF_API=$(vault_field secret/pi-fleet/terraform/cloudflare-api-token api-token)
+CF_ORIGIN=$(vault_field secret/pi-fleet/terraform/cloudflare-origin-ca-key origin-ca-key)
+TF_CLOUD=$(vault_field secret/pi-fleet/terraform/terraform-cloud-token token)
+PI_USER_VAL=$(vault_field secret/pi-fleet/terraform/pi-user pi-user)
+
+CLOUDFLARE_ZONE_ID=""
+CLOUDFLARE_ACCOUNT_ID=""
+PUBLIC_IP=""
+if [[ -f "$TERRAFORM_DIR/terraform.tfvars" ]]; then
+  CLOUDFLARE_ZONE_ID=$(grep '^cloudflare_zone_id' "$TERRAFORM_DIR/terraform.tfvars" 2>/dev/null | sed -n 's/.*= *"\([^"]*\)".*/\1/p' | head -1 || true)
+  CLOUDFLARE_ACCOUNT_ID=$(grep '^cloudflare_account_id' "$TERRAFORM_DIR/terraform.tfvars" 2>/dev/null | sed -n 's/.*= *"\([^"]*\)".*/\1/p' | head -1 || true)
+  PUBLIC_IP=$(grep '^public_ip' "$TERRAFORM_DIR/terraform.tfvars" 2>/dev/null | sed -n 's/.*= *"\([^"]*\)".*/\1/p' | head -1 || true)
+fi
+
+if [[ -z "$TF_CLOUD" ]]; then
+  TF_CLOUD="${TF_API_TOKEN:-${TF_TOKEN_app_terraform_io:-}}"
+fi
+
+# Optional: persist Terraform Cloud token in Vault when provided via env
+if [[ -n "$TF_CLOUD" ]]; then
+  kubectl exec -n vault "$VAULT_POD" -- \
+    env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${VAULT_TOKEN}" \
+    vault kv put secret/pi-fleet/terraform/terraform-cloud-token token="${TF_CLOUD}" >/dev/null 2>&1 \
+    && echo "Stored TF token in Vault (secret/pi-fleet/terraform/terraform-cloud-token)" || true
+fi
+
+if [[ -z "$CF_API" ]]; then
+  echo "Error: secret/pi-fleet/terraform/cloudflare-api-token not in Vault" >&2
+  exit 1
+fi
+
+for app in "${APPS[@]}"; do
+  echo "Syncing ($app)..."
+  set_gh_secret CLOUDFLARE_API_TOKEN "$CF_API" "$app"
+  set_gh_secret CLOUDFLARE_ORIGIN_CA_KEY "$CF_ORIGIN" "$app"
+  set_gh_secret TF_API_TOKEN "$TF_CLOUD" "$app"
+  set_gh_secret CLOUDFLARE_ZONE_ID "$CLOUDFLARE_ZONE_ID" "$app"
+  set_gh_secret CLOUDFLARE_ACCOUNT_ID "$CLOUDFLARE_ACCOUNT_ID" "$app"
+  set_gh_secret PUBLIC_IP "$PUBLIC_IP" "$app"
+  set_gh_secret PI_USER "$PI_USER_VAL" "$app"
+  echo ""
+done
+
+if [[ -z "$TF_CLOUD" ]]; then
+  echo "Note: TF_API_TOKEN not in Vault (secret/pi-fleet/terraform/terraform-cloud-token)."
+  echo "      Export TF_API_TOKEN (or TF_TOKEN_app_terraform_io) and re-run this script to sync + store in Vault."
+  echo "      GitHub Actions already has TF_API_TOKEN; Dependabot needs a separate copy:"
+  echo "        TF_API_TOKEN='…' $0 --app dependabot"
+else
+  echo "TF_API_TOKEN synced from Vault."
+fi
+
+echo "Done."

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -317,6 +317,8 @@ kubectl exec -n vault vault-0 -- vault kv put secret/openclaw/openrouter api-key
 
 If this secret was ever created by Terraform (`vault_kv_secret_v2.openclaw_openrouter`), **remove that address from remote state** after pulling the code change (the KV secret in Vault stays as-is). GitHub Actions only runs **plan/apply** — it does not run `terraform state rm`.
 
+**Dependabot PRs:** GitHub Actions secrets are **not** visible to Dependabot workflows. Run **`./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot`** (Cloudflare from Vault). For **`TF_API_TOKEN`**, export it and re-run (also stores in Vault at `secret/pi-fleet/terraform/terraform-cloud-token`): `TF_API_TOKEN='…' ./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot`
+
 **One-time (local CLI, same backend as CI):** state is in HCP Terraform org **`eldertree`**, workspace **`pi-fleet-terraform`**. Use a token with access to that workspace (org/team token, or the same capability as repo secret **`TF_API_TOKEN`** used by [`.github/workflows/terraform.yml`](../.github/workflows/terraform.yml)):
 
 ```bash

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -317,14 +317,14 @@ kubectl exec -n vault vault-0 -- vault kv put secret/openclaw/openrouter api-key
 
 If this secret was ever created by Terraform (`vault_kv_secret_v2.openclaw_openrouter`), **remove that address from remote state** after pulling the code change (the KV secret in Vault stays as-is). GitHub Actions only runs **plan/apply** — it does not run `terraform state rm`.
 
-**Dependabot PRs:** GitHub Actions secrets are **not** visible to Dependabot workflows. Run **`./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot`** (Cloudflare from Vault). For **`TF_API_TOKEN`**, export it and re-run (also stores in Vault at `secret/pi-fleet/terraform/terraform-cloud-token`): `TF_API_TOKEN='…' ./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot`
+**Secrets:** Vault is canonical — [`docs/VAULT_TERRAFORM_SECRETS.md`](../docs/VAULT_TERRAFORM_SECRETS.md). Local CLI: **`./run-terraform.sh`** loads from Vault. CI: sync with **`../scripts/sync-github-terraform-secrets-from-vault.sh`**.
 
-**One-time (local CLI, same backend as CI):** state is in HCP Terraform org **`eldertree`**, workspace **`pi-fleet-terraform`**. Use a token with access to that workspace (org/team token, or the same capability as repo secret **`TF_API_TOKEN`** used by [`.github/workflows/terraform.yml`](../.github/workflows/terraform.yml)):
+**One-time (local CLI, same backend as CI):** org **`eldertree`**, workspace **`pi-fleet-terraform`**. Bootstrap token in Vault, then:
 
 ```bash
+../scripts/setup-terraform-cloud-token.sh   # or --sync-github
 cd terraform
-export TF_TOKEN_app_terraform_io="<your-terraform-cloud-token>"
-terraform init -input=false
+./run-terraform.sh init -input=false
 terraform state rm 'vault_kv_secret_v2.openclaw_openrouter[0]'
 ```
 

--- a/terraform/run-terraform.sh
+++ b/terraform/run-terraform.sh
@@ -45,7 +45,7 @@ else
 fi
 
 if [ -z "${TF_TOKEN_app_terraform_io:-}" ]; then
-    echo "❌ HCP Terraform token not in Vault (secret/pi-fleet/terraform/terraform-cloud-token)"
+    echo "❌ HCP Terraform token not in Vault (secret/pi-fleet/terraform/eldertree-github-2026)"
     echo "   Run: ${REPO_DIR}/scripts/setup-terraform-cloud-token.sh"
     exit 1
 else

--- a/terraform/run-terraform.sh
+++ b/terraform/run-terraform.sh
@@ -12,75 +12,48 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$SCRIPT_DIR"
 
-# Set kubeconfig
-export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
+# shellcheck source=../scripts/lib/load-terraform-secrets-from-vault.sh
+source "${REPO_DIR}/scripts/lib/load-terraform-secrets-from-vault.sh"
 
-# Get Cloudflare API token from Vault
-echo "🔐 Loading Cloudflare API token from Vault..."
-VAULT_POD=$(kubectl get pods -n vault -l app.kubernetes.io/name=vault -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-
-if [ -z "$VAULT_POD" ]; then
-    echo "❌ Error: Vault pod not found"
-    echo "   Make sure Vault is running: kubectl get pods -n vault"
+echo "🔐 Loading Terraform secrets from Vault..."
+if ! kubectl get pods -n vault -l app.kubernetes.io/name=vault --field-selector=status.phase=Running -o name 2>/dev/null | grep -q .; then
+    echo "❌ Error: no running Vault pod (kubectl get pods -n vault)"
     exit 1
 fi
 
-# Check if Vault is unsealed
-VAULT_STATUS=$(kubectl exec -n vault $VAULT_POD -- vault status 2>&1 | grep "Sealed" | awk '{print $2}' || echo "true")
+load_terraform_secrets_from_vault
 
-if [ "$VAULT_STATUS" = "true" ]; then
-    echo "❌ Error: Vault is sealed. Please unseal it first:"
-    echo "   cd $SCRIPT_DIR/.. && ./scripts/operations/unseal-vault.sh"
-    exit 1
-fi
-
-# Get Cloudflare API token from Vault (optional - Cloudflare resources are optional)
-export TF_VAR_cloudflare_api_token=$(kubectl exec -n vault $VAULT_POD -- vault kv get -field=api-token secret/pi-fleet/terraform/cloudflare-api-token 2>/dev/null || echo "")
-
-if [ -z "$TF_VAR_cloudflare_api_token" ]; then
-    echo "⚠️  Cloudflare API token not found in Vault"
-    echo "   Cloudflare resources will be skipped (tunnel, DNS records)"
-    
-    # Check if Cloudflare resources exist in state
+CLOUDFLARE_TOKEN_MISSING=false
+if [ -z "${TF_VAR_cloudflare_api_token:-}" ]; then
+    echo "⚠️  Cloudflare API token not in Vault (secret/pi-fleet/terraform/cloudflare-api-token)"
     CLOUDFLARE_RESOURCES=$(terraform state list 2>/dev/null | grep -E "cloudflare|data.cloudflare" || echo "")
-    
     if [ -n "$CLOUDFLARE_RESOURCES" ]; then
-        echo ""
-        echo "⚠️  WARNING: Cloudflare resources exist in Terraform state but token is missing"
-        echo "   Using -refresh=false to skip refreshing Cloudflare resources (avoids auth errors)"
-        echo "   Cloudflare resources will be removed from state on next apply."
-        echo ""
+        echo "⚠️  Cloudflare resources in state — plan/apply will use -refresh=false"
         CLOUDFLARE_TOKEN_MISSING=true
     fi
-    
-    echo "   To enable Cloudflare:"
-    echo "     1. Store token: kubectl exec -n vault $VAULT_POD -- vault kv put secret/pi-fleet/terraform/cloudflare-api-token api-token='YOUR_TOKEN'"
-    echo "     2. Re-run: $0 $@"
-    echo ""
-    export TF_VAR_cloudflare_api_token=""
 else
-    echo "✅ Cloudflare API token loaded from Vault"
+    echo "✅ Cloudflare API token"
 fi
 
-# Get Cloudflare Origin CA Key from Vault (required for Origin CA certificates)
-export TF_VAR_cloudflare_origin_ca_key=$(kubectl exec -n vault $VAULT_POD -- vault kv get -field=origin-ca-key secret/pi-fleet/terraform/cloudflare-origin-ca-key 2>/dev/null || echo "")
-
-if [ -z "$TF_VAR_cloudflare_origin_ca_key" ]; then
-    echo "⚠️  Cloudflare Origin CA Key not found in Vault"
-    echo "   Origin CA certificate resources will be skipped"
-    export TF_VAR_cloudflare_origin_ca_key=""
+if [ -z "${TF_VAR_cloudflare_origin_ca_key:-}" ]; then
+    echo "⚠️  Cloudflare Origin CA key not in Vault"
 else
-    echo "✅ Cloudflare Origin CA Key loaded from Vault"
+    echo "✅ Cloudflare Origin CA key"
 fi
 
-# Get pi_user from Vault (optional, falls back to default "pi")
-export TF_VAR_pi_user=$(kubectl exec -n vault $VAULT_POD -- vault kv get -field=pi-user secret/pi-fleet/terraform/pi-user 2>/dev/null || echo "")
-if [ -n "$TF_VAR_pi_user" ]; then
-    echo "✅ Pi username loaded from Vault"
+if [ -z "${TF_TOKEN_app_terraform_io:-}" ]; then
+    echo "❌ HCP Terraform token not in Vault (secret/pi-fleet/terraform/terraform-cloud-token)"
+    echo "   Run: ${REPO_DIR}/scripts/setup-terraform-cloud-token.sh"
+    exit 1
 else
-    echo "ℹ️  Pi username not found in Vault, will use default or terraform.tfvars"
+    echo "✅ HCP Terraform token (TF_TOKEN_app_terraform_io)"
+fi
+
+if [ -n "${TF_VAR_pi_user:-}" ]; then
+    echo "✅ Pi username"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

- Adds `scripts/sync-github-terraform-secrets-from-vault.sh` (Cloudflare from Vault → Dependabot).
- Fixes `get-vault-secret.sh` to use ESO `vault-token`.
- Documents Dependabot vs Actions secrets in CONTRIBUTING.md (explains historical red runs).

## Context

[Actions page](https://github.com/raolivei/pi-fleet/actions) shows many failures, but **`main` Terraform is green** (latest: checkout bump merge). Failures are mostly:
- Old Dependabot `TF_API_TOKEN` miss (PR #175 merged despite red check)
- 3× failed experimental `sync-dependabot-secrets` workflow on orphan branch `fix/dependabot-secrets-from-vault` (workflow removed; branch can be deleted after this merges)

## Test plan

- [ ] Merge PR
- [ ] Delete remote branch `fix/dependabot-secrets-from-vault` if still present
- [ ] Optional: `TF_API_TOKEN='…' ./scripts/sync-github-terraform-secrets-from-vault.sh --app dependabot` for future Dependabot PRs


Made with [Cursor](https://cursor.com)