### PR TITLE
fix: Terraform ExternalSecret without optional pi-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Fixed
+
+- **ExternalSecret `pi-fleet-terraform-vault-credentials`** — drop optional `pi-user` Vault key so sync succeeds when that secret is absent.
+
 ### Changed
 
 - **Grafana (monitoring-stack 0.2.11)** — `hardware-health` and `eldertree-ops-home` panels for watchdog, freeze signal, OOM, and node uptime/reboot (metrics behind `WatchdogServiceDown`, `NodePingableButNotReady`, `NodeUnexpectedReboot`).

--- a/clusters/eldertree/secrets-management/external-secrets/externalsecrets/terraform-vault-credentials.yaml
+++ b/clusters/eldertree/secrets-management/external-secrets/externalsecrets/terraform-vault-credentials.yaml
@@ -26,7 +26,4 @@ spec:
       remoteRef:
         key: secret/pi-fleet/terraform/eldertree-github-2026
         property: token
-    - secretKey: pi-user
-      remoteRef:
-        key: secret/pi-fleet/terraform/pi-user
-        property: pi-user
+    # pi-user: optional; add when secret/pi-fleet/terraform/pi-user exists in Vault


### PR DESCRIPTION
## Summary
- Remove `pi-user` from `pi-fleet-terraform-vault-credentials` ExternalSecret so ESO can sync when that optional Vault path is missing.

## Test plan
- [ ] Merge and `flux reconcile` external-secrets kustomization
- [ ] `kubectl get externalsecret pi-fleet-terraform-vault-credentials -n external-secrets` → Ready=True

Made with [Cursor](https://cursor.com)