### PR TITLE
Deploy Ollie v0.4.0 to eldertree cluster

### DIFF
--- a/clusters/eldertree/kustomization.yaml
+++ b/clusters/eldertree/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - canopy # Personal finance dashboard
   - swimto # Toronto pool schedules
   - pitanga/flux-kustomization.yaml # Pitanga Cloud (managed by its own Flux Kustomization)
+  - ollie # Workspace assistant with RAG and LLM
   # - nima          # AI/ML learning project (DISABLED - not needed)
   # - journey       # AI-powered career pathfinder (DISABLED - not deployed yet)
   # - us-law-severity-map  # US law visualization (DISABLED - not deployed yet)

--- a/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
+++ b/clusters/eldertree/observability/monitoring-stack-helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/monitoring-stack
-      version: "0.2.11"
+      version: "0.2.12"
       sourceRef:
         kind: GitRepository
         name: flux-system

--- a/clusters/eldertree/ollie/ghcr-secret-external.yaml
+++ b/clusters/eldertree/ollie/ghcr-secret-external.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-secret
+  namespace: ollie
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-secret
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "{{ .username }}",
+                "password": "{{ .password }}"
+              }
+            }
+          }
+  data:
+    - secretKey: username
+      remoteRef:
+        key: secret/pi-fleet/ghcr
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: secret/pi-fleet/ghcr
+        property: token

--- a/clusters/eldertree/ollie/helmrelease.yaml
+++ b/clusters/eldertree/ollie/helmrelease.yaml
@@ -1,0 +1,51 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ollie
+  namespace: ollie
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: ./helm/ollie
+      version: "0.1.0"
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 30m
+  values:
+    audio:
+      enabled: false
+    ollama:
+      externalUrl: "http://host.docker.internal:11434"
+      deployOnCluster: false
+    elder:
+      url: "http://elder.openclaw.svc.cluster.local:8000"
+    workspace:
+      root: "/workspace"
+      hostPath: "/mnt/workspace"
+    monitoring:
+      enabled: true
+      port: "8000"
+      path: "/metrics"
+    core:
+      image:
+        repository: ghcr.io/raolivei/ollie-core
+        tag: v0.4.0
+        pullPolicy: Always
+      resources:
+        requests:
+          memory: "512Mi"
+          cpu: "200m"
+        limits:
+          memory: "1Gi"
+          cpu: "1000m"
+    frontend:
+      enabled: true
+      image:
+        repository: ghcr.io/raolivei/ollie-frontend
+        tag: v0.2.0
+        pullPolicy: Always
+  imagePullSecrets:
+    - name: ghcr-secret

--- a/clusters/eldertree/ollie/kustomization.yaml
+++ b/clusters/eldertree/ollie/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - ghcr-secret-external.yaml
+  - ollie-secrets-external.yaml
+  - helmrelease.yaml

--- a/clusters/eldertree/ollie/namespace.yaml
+++ b/clusters/eldertree/ollie/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollie
+  labels:
+    app: ollie

--- a/clusters/eldertree/ollie/ollie-secrets-external.yaml
+++ b/clusters/eldertree/ollie/ollie-secrets-external.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ollie-secrets
+  namespace: ollie
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ollie-secrets
+  data:
+    - secretKey: elder-api-key
+      remoteRef:
+        key: secret/pi-fleet/ollie
+        property: elder_api_key
+    - secretKey: openrouter-api-key
+      remoteRef:
+        key: secret/pi-fleet/ollie
+        property: openrouter_api_key

--- a/helm/monitoring-stack/Chart.yaml
+++ b/helm/monitoring-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring-stack
 description: Complete monitoring stack with Prometheus and Grafana for pi-fleet
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "1.0"
 dependencies:
   - name: prometheus

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -392,6 +392,7 @@ grafana:
     pitanga-dashboard: "Applications/Pitanga"
     visage-operations: "Applications/Visage"
     visage-training: "Applications/Visage"
+    ollie-dashboard: "Applications/Ollie"
     # —— Platform (cluster, capacity, network, security) ——
     eldertree-ops-home: "Platform/Overview"
     command-center: "Platform/Overview"


### PR DESCRIPTION
Deploy workspace assistant with Prometheus observability.

## Changes
- Add FluxCD manifests for ollie namespace
- Configure ExternalSecrets for API keys
- Register Grafana dashboard
- Bump monitoring-stack to 0.2.12

## Verification
- kubectl get pods -n ollie
- Visit prometheus/grafana targets