### PR TITLE
fix: Ollie HelmRelease API v2beta1 → v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Ollie HelmRelease API** — bump `clusters/eldertree/ollie/helmrelease.yaml` from deprecated `helm.toolkit.fluxcd.io/v2beta1` to `v2` so `flux-system` kustomization dry-run succeeds (cluster CRD no longer serves `v2beta1`).
 - **ExternalSecret `pi-fleet-terraform-vault-credentials`** — drop optional `pi-user` Vault key so sync succeeds when that secret is absent.
 
 ### Changed

--- a/clusters/eldertree/ollie/helmrelease.yaml
+++ b/clusters/eldertree/ollie/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ollie


### PR DESCRIPTION
## Summary

- Bump `clusters/eldertree/ollie/helmrelease.yaml` from `helm.toolkit.fluxcd.io/v2beta1` to `v2`
- Unblocks `flux-system` kustomization (dry-run was failing after Flux CRD dropped `v2beta1`)

## Test plan

- [ ] Merge and `flux reconcile kustomization flux-system -n flux-system`
- [ ] Confirm `flux get kustomization flux-system` shows `READY=True`
- [ ] Confirm Ollie HelmRelease reconciles in namespace `ollie`


Made with [Cursor](https://cursor.com)