### PR TITLE
chore(elder): pin Control Center image to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.0` (Control Center SPA + `/api/public/cluster/health`); ImageRepository tracks `elder` instead of legacy `grove`. Ingress `control.eldertree.local` → Elder service.
 - **Visage archived (2026-04)** — Detached live monitoring (scrape, dashboards, exporter targets), tunnel/DNS, and hosts/Caddy entries; preserved reference copies under [`docs/archive/visage/`](docs/archive/visage/). See [`workspace-config/docs/PROJECT_DECOMMISSIONING.md`](../workspace-config/docs/PROJECT_DECOMMISSIONING.md).
 - **Repo layout** — Moved `NETWORK.md`, `VAULT.md`, and `SERVICES_REFERENCE.md` into `docs/`; blog drafts and one-off session notes into `docs/archive/`; removed duplicate `blog/` tree at repo root. Root now holds README, CHANGELOG, CLAUDE, CONTRIBUTING, and `VERSION` only.
 
@@ -21,6 +22,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Ollie HelmRelease** — remove invalid top-level `spec.imagePullSecrets` (not in `helm.toolkit.fluxcd.io/v2` schema); unblocks `flux-system` kustomization dry-run.
 - **Ollie HelmRelease API** — bump `clusters/eldertree/ollie/helmrelease.yaml` from deprecated `helm.toolkit.fluxcd.io/v2beta1` to `v2` so `flux-system` kustomization dry-run succeeds (cluster CRD no longer serves `v2beta1`).
 - **ExternalSecret `pi-fleet-terraform-vault-credentials`** — drop optional `pi-user` Vault key so sync succeeds when that secret is absent.
 

--- a/clusters/eldertree/ollie/helmrelease.yaml
+++ b/clusters/eldertree/ollie/helmrelease.yaml
@@ -47,5 +47,3 @@ spec:
         repository: ghcr.io/raolivei/ollie-frontend
         tag: v0.2.0
         pullPolicy: Always
-  imagePullSecrets:
-    - name: ghcr-secret

--- a/clusters/eldertree/openclaw/elder-image-repo.yaml
+++ b/clusters/eldertree/openclaw/elder-image-repo.yaml
@@ -4,8 +4,8 @@ metadata:
   name: elder
   namespace: openclaw
 spec:
-  # Same image as Grove (app renamed to Elder; image not yet published as elder)
-  image: ghcr.io/raolivei/grove
+  # Elder Control Center + API (published as ghcr.io/raolivei/elder)
+  image: ghcr.io/raolivei/elder
   interval: 30m
   secretRef:
     name: ghcr-secret

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -137,8 +137,8 @@ spec:
 
       elder:
         image:
-          repository: ghcr.io/raolivei/grove
-          tag: v0.2.0 # {"$imagepolicy": "openclaw:elder:tag"}
+          repository: ghcr.io/raolivei/elder
+          tag: v0.3.0 # {"$imagepolicy": "openclaw:elder:tag"}
           pullPolicy: Always
         port: 8006
         servicePort: 8000

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -138,7 +138,7 @@ spec:
       elder:
         image:
           repository: ghcr.io/raolivei/elder
-          tag: v0.3.0 # {"$imagepolicy": "openclaw:elder:tag"}
+          tag: v0.3.1 # {"$imagepolicy": "openclaw:elder:tag"}
           pullPolicy: Always
         port: 8006
         servicePort: 8000


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/raolivei/elder` to **v0.3.1** (fixes COMPONENT_TARGETS deployment names and LAN Grafana URLs in Control Center).
- Follows elder `581d873` on main; image built and pushed by CI.

## Test plan
- [x] `gh run list --repo raolivei/elder` — Build and Push success for v0.3.1
- [ ] After merge: `flux reconcile helmrelease openclaw -n openclaw`
- [ ] `curl -sk https://control.eldertree.local/api/public/cluster/health` — components not all `unknown`
- [ ] `https://control.eldertree.local/` returns 200

Made with [Cursor](https://cursor.com)