### PR TITLE
docs: service routing onboarding and Control Center ops guide

### DIFF
--- a/.claude/agents/eldertree-infraops.md
+++ b/.claude/agents/eldertree-infraops.md
@@ -22,6 +22,7 @@ You are the **Eldertree infrastructure operations agent**. For every task:
 
 ## Incident workflow
 
+0. **On LAN/Tailscale:** [Control Center](https://control.eldertree.local) or `curl -sk https://control.eldertree.local/api/public/cluster/health` — one-glance topology before opening Grafana.
 1. Grafana/Prometheus: node Ready, load, memory, boot time, `probe_success`, app `up`.
 2. Loki: namespace / pod logs for the window.
 3. `kubectl get nodes,pods -A` (use node-2 API if VIP down).
@@ -33,6 +34,7 @@ You are the **Eldertree infrastructure operations agent**. For every task:
 - Monitoring chart: `pi-fleet/helm/monitoring-stack/`
 - Dashboard index: `pi-fleet/helm/monitoring-stack/DASHBOARDS.md`
 - App onboarding: `pi-fleet/docs/ONBOARDING_APP_OBSERVABILITY.md`
+- **LAN routing onboarding:** `pi-fleet/docs/ONBOARDING_APP_ROUTING.md` — run `./scripts/verify-service-routing.sh --host <fqdn>` after every new ingress
 - Watchdog: `pi-fleet/docs/HARDWARE_WATCHDOG.md`
 - Blackbox: `pi-fleet/docs/OBSERVABILITY_BLACKBOX_AND_SYNTHETIC.md`
 
@@ -43,6 +45,16 @@ flux reconcile source git flux-system -n flux-system
 flux reconcile kustomization flux-system -n flux-system --with-source
 flux reconcile helmrelease monitoring-stack -n observability --force
 ```
+
+**HelmRelease API:** `helm.toolkit.fluxcd.io/v2` only. If `flux-system` not Ready, check dry-run errors on individual HelmReleases (e.g. deprecated `v2beta1`).
+
+**Stale PR branches:** merge `main` before reopening old feature branches that were partially superseded by other merges.
+
+## Key paths (Control Center)
+
+- Ops doc: `pi-fleet/docs/CONTROL_CENTER.md`
+- Ingress: `pi-fleet/clusters/eldertree/openclaw/helmrelease.yaml` (`control-center`)
+- Elder SPA/API: [elder](https://github.com/raolivei/elder) repo `frontend/` + `docs/PUBLIC_CLUSTER_API.md`
 
 ## Legacy handoff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **Local routing sync** — `eldertree-local-hosts-block.txt`, `add-services-to-hosts.sh`, and `Caddyfile` aligned with registry (openclaw, alertmanager, docs, dex, audio, canopy, journey, nima).
 - **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.0` (Control Center SPA + `/api/public/cluster/health`); ImageRepository tracks `elder` instead of legacy `grove`. Ingress `control.eldertree.local` → Elder service.
 - **Visage archived (2026-04)** — Detached live monitoring (scrape, dashboards, exporter targets), tunnel/DNS, and hosts/Caddy entries; preserved reference copies under [`docs/archive/visage/`](docs/archive/visage/). See [`workspace-config/docs/PROJECT_DECOMMISSIONING.md`](../workspace-config/docs/PROJECT_DECOMMISSIONING.md).
 - **Repo layout** — Moved `NETWORK.md`, `VAULT.md`, and `SERVICES_REFERENCE.md` into `docs/`; blog drafts and one-off session notes into `docs/archive/`; removed duplicate `blog/` tree at repo root. Root now holds README, CHANGELOG, CLAUDE, CONTRIBUTING, and `VERSION` only.
 
 ### Added
 
+- **Service routing onboarding** — [`docs/ONBOARDING_APP_ROUTING.md`](docs/ONBOARDING_APP_ROUTING.md): end-to-end LAN checklist; [`docs/eldertree-local-services.yaml`](docs/eldertree-local-services.yaml) registry; [`scripts/check-local-routing-registry.sh`](scripts/check-local-routing-registry.sh) and [`scripts/verify-service-routing.sh`](scripts/verify-service-routing.sh) for cluster + Pi-hole + Mac verification.
 - **Observability retention (NVMe)** — [`docs/OBSERVABILITY_RETENTION.md`](docs/OBSERVABILITY_RETENTION.md): 90d Prometheus metrics (64Gi `local-path-nvme`, `retentionSize: 58GB`), 30d Loki logs (48Gi NVMe, extend to 90d after measure), stable-node affinity, Promtail probe/health log drops, PVC migration runbook. monitoring-stack chart **0.2.13**.
+- **Control Center ops doc** — [`docs/CONTROL_CENTER.md`](docs/CONTROL_CENTER.md): architecture, URLs, API, troubleshooting for `control.eldertree.local`.
 - **Control Center local dev** — `control.eldertree.local` in `scripts/Caddyfile`, `add-services-to-hosts.sh`, `setup-caddy-proxy.sh`, and `docs/eldertree-local-hosts-block.txt` for LAN Caddy testing of the Elder ops console (cluster ingress via OpenClaw HelmRelease).
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@
 - **Commit format**: `<type>: <description>` (e.g., `feat: add monitoring`, `fix: dns-config`)
 - **Workflow**: `git checkout main → git pull → git checkout -b <type>/<name>`
 
+### New LAN service (Ollie / agents)
+
+Any new `*.eldertree.local` app **must** include in the same PR: registry entry (`docs/eldertree-local-services.yaml`), Ingress + external-dns, hosts block + `add-services-to-hosts.sh` + `Caddyfile`. Run `./scripts/check-local-routing-registry.sh` before merge and `./scripts/verify-service-routing.sh --host <fqdn>` after deploy. See [ONBOARDING_APP_ROUTING.md](docs/ONBOARDING_APP_ROUTING.md) and `ollie/memory/feedback_eldertree_service_routing_e2e.md`.
+
 ### Versioning & Changes
 - **Git tag versions must match Docker image tags** - Ensure consistency across releases
 - **ANY Docker image changes must update CHANGELOG.md** - Dockerfiles, base images, tags in manifests
@@ -45,10 +49,17 @@
 
 ## Eldertree InfraOPS & observability
 
-- **Agent handoff:** [`.claude/agents/eldertree-infraops.md`](.claude/agents/eldertree-infraops.md) — use **Prometheus/Grafana/Loki first** on every incident.
+- **Agent handoff:** [`.claude/agents/eldertree-infraops.md`](.claude/agents/eldertree-infraops.md) — use **Prometheus/Grafana/Loki first** on every incident; **Control Center** for one-glance topology when on LAN/Tailscale.
+- **Control Center:** [`docs/CONTROL_CENTER.md`](docs/CONTROL_CENTER.md) — `https://control.eldertree.local` (Elder SPA + `/api/public/cluster/health`).
 - **Workspace o11y standard:** [`../workspace-config/docs/OBSERVABILITY_STANDARDS.md`](../workspace-config/docs/OBSERVABILITY_STANDARDS.md)
+- **Retention / NVMe:** [`docs/OBSERVABILITY_RETENTION.md`](docs/OBSERVABILITY_RETENTION.md)
 - **New app checklist:** [`docs/ONBOARDING_APP_OBSERVABILITY.md`](docs/ONBOARDING_APP_OBSERVABILITY.md)
 - **Dashboard map:** [`helm/monitoring-stack/DASHBOARDS.md`](helm/monitoring-stack/DASHBOARDS.md)
+
+### Flux HelmRelease
+
+- Use **`apiVersion: helm.toolkit.fluxcd.io/v2`** only — `v2beta1` blocks `flux-system` reconciliation.
+- Grep: `rg 'v2beta1' clusters/eldertree/` before merge.
 
 ## When to Read What
 
@@ -87,6 +98,7 @@
 
 ### Ingress & Access
 - **Ingress setup?** → [docs/INGRESS.md](docs/INGRESS.md)
+- **New app LAN routing?** → [docs/ONBOARDING_APP_ROUTING.md](docs/ONBOARDING_APP_ROUTING.md)
 - **Lens connection?** → [docs/LENS_CONNECTION_GUIDE.md](docs/LENS_CONNECTION_GUIDE.md)
 
 ### Storage & Backup

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ scripts/           # Helper scripts (setup-eldertree.sh, etc.)
 
 - **Synthetic / Blackbox HTTP monitoring (why and how on Eldertree):** [docs/OBSERVABILITY_BLACKBOX_AND_SYNTHETIC.md](docs/OBSERVABILITY_BLACKBOX_AND_SYNTHETIC.md)
 - **Retention & NVMe sizing (90d metrics, 30d logs):** [docs/OBSERVABILITY_RETENTION.md](docs/OBSERVABILITY_RETENTION.md)
+- **Control Center (live topology + health):** [docs/CONTROL_CENTER.md](docs/CONTROL_CENTER.md)
+- **New app routing (LAN end-to-end):** [docs/ONBOARDING_APP_ROUTING.md](docs/ONBOARDING_APP_ROUTING.md)
 - **Grafana dashboard inventory and PromQL source of truth:** [helm/monitoring-stack/DASHBOARDS.md](helm/monitoring-stack/DASHBOARDS.md)
 
 ## Helm Charts

--- a/clusters/eldertree/openclaw/README.md
+++ b/clusters/eldertree/openclaw/README.md
@@ -25,6 +25,7 @@ To rebuild manually:
 - **SwimTO Integration**: Query Toronto pool schedules
 - **Kubernetes Access**: Cluster-wide operator RBAC via in-pod `kubectl` (workloads, Flux, ingress, secrets, etc.); storage (PV/PVC/snapshots/StorageClass) and cluster control-plane APIs are read-only — see [rbac.yaml](rbac.yaml)
 - **Elder Agent**: Code browsing, GitHub issues/PRs, FluxCD, project planning
+- **Control Center**: Live cluster topology + health at `https://control.eldertree.local` (Elder SPA; LAN/Tailscale) — see [CONTROL_CENTER.md](../../../docs/CONTROL_CENTER.md)
 - **Web Search**: Brave Search API
 - **Web UI**: `https://openclaw.eldertree.local`
 

--- a/clusters/eldertree/openclaw/docs/ELDERTREE_KNOWLEDGE.md
+++ b/clusters/eldertree/openclaw/docs/ELDERTREE_KNOWLEDGE.md
@@ -52,6 +52,7 @@ This document provides comprehensive infrastructure context for OpenClaw/Elder. 
 | NIMA      | https://nima.eldertree.local      | nima      | AI/ML learning                             |
 | OpenClaw  | https://openclaw.eldertree.local  | openclaw  | AI assistant; Telegram: @eldertree_assistant_bot |
 | Elder     | https://elder.eldertree.local     | openclaw  | AI agent sidecar; Swagger: /docs           |
+| Control Center | https://control.eldertree.local | openclaw  | Live ops topology + health (Elder SPA); LAN/Tailscale |
 | Pitanga   | https://pitanga.eldertree.local    | pitanga   | Company site; public: pitanga.cloud         |
 
 ---

--- a/docs/CONTROL_CENTER.md
+++ b/docs/CONTROL_CENTER.md
@@ -1,0 +1,83 @@
+# Eldertree Control Center
+
+Live ops console for the homelab cluster: OSI-layered topology, workload health, Grafana links, and runbook index. **LAN / Tailscale only** — not exposed on the public internet.
+
+## URLs
+
+| Environment | URL | Notes |
+|-------------|-----|--------|
+| Cluster (LAN) | `https://control.eldertree.local` | Traefik ingress → Elder service `:8000` |
+| Elder API (same host) | `https://control.eldertree.local/api/public/cluster/health` | JSON health payload |
+| Elder API (alternate) | `https://elder.eldertree.local` | Same backend; Swagger at `/docs` |
+| Local dev (SPA) | `http://localhost:5174` | `cd elder/frontend && npm run dev` (proxies API to Elder `:8006`) |
+
+Add `control.eldertree.local` to `/etc/hosts` or Pi-hole (see [`eldertree-local-hosts-block.txt`](eldertree-local-hosts-block.txt)) and optional Caddy proxy ([`scripts/Caddyfile`](../scripts/Caddyfile)).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Browser["Browser\n(LAN / Tailscale)"]
+  Traefik["Traefik\ningress"]
+  Elder["Elder pod\nFastAPI + SPA"]
+  K8s["Kubernetes API"]
+  Flux["Flux Kustomizations"]
+
+  Browser --> Traefik
+  Traefik --> Elder
+  Elder --> K8s
+  Elder --> Flux
+```
+
+- **Frontend:** React SPA in [elder/frontend](https://github.com/raolivei/elder/tree/main/frontend) — built into the Elder Docker image and served at `/`.
+- **Backend:** [Elder](https://github.com/raolivei/elder) — `GET /api/public/cluster/health` (no API key; CORS restricted to trusted origins).
+- **GitOps:** Ingress `control-center` in [`clusters/eldertree/openclaw/helmrelease.yaml`](../clusters/eldertree/openclaw/helmrelease.yaml); image `ghcr.io/raolivei/elder` (see OpenClaw HelmRelease `elder` values).
+
+## Features
+
+| Feature | Source |
+|---------|--------|
+| Node Ready status | K8s nodes API |
+| Component health (Deployments/StatefulSets) | `list_component_health()` catalog |
+| Flux readiness counts | Flux Kustomization status |
+| Topology (OSI lanes, dependency links) | Frontend catalog + health poll |
+| Health colors | 30s poll; green / amber / red / grey |
+| Grafana deep links | Panel → `grafana.eldertree.xyz` |
+| Runbooks | Static index → [eldertree-docs](https://docs.eldertree.xyz/runbook/) |
+
+## API
+
+Full schema and CORS policy: [elder/docs/PUBLIC_CLUSTER_API.md](https://github.com/raolivei/elder/blob/main/docs/PUBLIC_CLUSTER_API.md)
+
+Quick check:
+
+```bash
+curl -sS https://control.eldertree.local/api/public/cluster/health | jq '{updated, flux: "\(.flux_ready)/\(.flux_total)", down: [.components[] | select(.status == "down" or .status == "degraded") | .id]}'
+```
+
+## Related consumers
+
+| Site | Endpoint | Purpose |
+|------|----------|---------|
+| Control Center | `/api/public/cluster/health` | Full topology health |
+| Blog / docs home widgets | `/api/public/cluster/nodes` | Node glance only |
+| Blog (public GitHub Pages) | `/cluster-status.json` | Build-time snapshot when Elder unreachable |
+
+Narrative write-up: [Building Eldertree — Chapter 21](https://blog.eldertree.xyz/chapters/21-the-control-center-because-i-needed-to-know-from-afar).
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| HTTP 503 | `kubectl get pods -n openclaw -l app=elder`; Elder endpoints empty → image pull or crash |
+| All grey components | RBAC or wrong Deployment names in Elder catalog |
+| DNS fails | `control.eldertree.local` in hosts/Pi-hole; external-dns annotation on ingress |
+| CORS error from dev | Elder `debug=true` or add origin in `PUBLIC_CORS_ORIGINS` |
+
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+kubectl get ingress control-center -n openclaw
+kubectl get deploy elder -n openclaw
+kubectl logs -n openclaw deploy/elder --tail=50
+flux reconcile helmrelease openclaw -n openclaw
+```

--- a/docs/INGRESS.md
+++ b/docs/INGRESS.md
@@ -2,6 +2,8 @@
 
 Complete guide on configuring and using Traefik Ingress Controller, Cert-Manager, and ExternalDNS in the k3s cluster.
 
+**New app?** Start with **[ONBOARDING_APP_ROUTING.md](ONBOARDING_APP_ROUTING.md)** — end-to-end checklist and `./scripts/verify-service-routing.sh` so Mac/LAN access works before merge.
+
 ## Overview
 
 The cluster uses three main components to manage HTTP/HTTPS traffic and DNS:

--- a/docs/ONBOARDING_APP_OBSERVABILITY.md
+++ b/docs/ONBOARDING_APP_OBSERVABILITY.md
@@ -1,5 +1,7 @@
 # Onboarding a new Eldertree app to Prometheus & Grafana
 
+**Routing first:** [ONBOARDING_APP_ROUTING.md](ONBOARDING_APP_ROUTING.md) — Ingress, Pi-hole, hosts, Caddy, `./scripts/verify-service-routing.sh`.
+
 Workspace standard: [`workspace-config/docs/OBSERVABILITY_STANDARDS.md`](../../workspace-config/docs/OBSERVABILITY_STANDARDS.md)
 
 ## Checklist (single PR to `pi-fleet`)

--- a/docs/ONBOARDING_APP_ROUTING.md
+++ b/docs/ONBOARDING_APP_ROUTING.md
@@ -1,0 +1,171 @@
+# Onboarding a new Eldertree app — routing & access (end-to-end)
+
+When a new service deploys but **does not load on your Mac**, the failure is rarely one thing. Traffic crosses several layers; skipping any of them breaks “it works in the cluster” vs “it works in my browser.”
+
+**Goal:** Every new LAN-facing app passes `./scripts/verify-service-routing.sh --host <fqdn>` before the PR merges.
+
+Related: [ONBOARDING_APP_OBSERVABILITY.md](ONBOARDING_APP_OBSERVABILITY.md) (metrics/Grafana) · [INGRESS.md](INGRESS.md) (Traefik/cert-manager/external-dns details)
+
+---
+
+## The path a request takes
+
+```mermaid
+flowchart LR
+  Browser["Browser on Mac"]
+  Caddy["Caddy optional\n:443 local certs"]
+  DNS["Pi-hole DNS\nor /etc/hosts"]
+  Traefik["Traefik Ingress"]
+  Svc["Service"]
+  Pod["Pods"]
+
+  Browser --> Caddy
+  Caddy --> DNS
+  DNS --> Traefik
+  Traefik --> Svc
+  Pod --> Svc
+```
+
+**Cluster-only fixes** (Ingress, pods) do not help if **Pi-hole**, **/etc/hosts**, or **Caddy** on the Mac are stale. That is why routing changes often feel like whack-a-mole.
+
+---
+
+## Single source of truth
+
+**[`docs/eldertree-local-services.yaml`](eldertree-local-services.yaml)** — canonical list of `*.eldertree.local` hostnames.
+
+When adding a service, **register the host here first**, then update the other files (or run the sync checker until green).
+
+Enforced copies (must list every registry host):
+
+| File | Purpose |
+|------|---------|
+| [`docs/eldertree-local-hosts-block.txt`](eldertree-local-hosts-block.txt) | Tailscale / manual `/etc/hosts` block |
+| [`scripts/add-services-to-hosts.sh`](../scripts/add-services-to-hosts.sh) | `sudo` helper to append hosts |
+| [`scripts/Caddyfile`](../scripts/Caddyfile) | Local HTTPS proxy → Traefik NodePort (when not using Pi-hole-only) |
+
+Also update [`docs/SERVICES_REFERENCE.md`](SERVICES_REFERENCE.md) for humans.
+
+---
+
+## Checklist (single pi-fleet PR + app PR if needed)
+
+### A. Cluster (GitOps)
+
+- [ ] **Deployment / StatefulSet** Ready; **Service** exists
+- [ ] **Ingress** (or `eldertree-app` HelmRelease `ingress:`) with:
+  - `host: <app>.eldertree.local`
+  - `ingressClassName: traefik`
+  - TLS + `cert-manager.io/cluster-issuer: ca-cluster-issuer` (or chart default)
+  - **`external-dns.alpha.kubernetes.io/hostname: <app>.eldertree.local`**
+- [ ] Backend **Service name and port** match Ingress (typo = 503)
+- [ ] App **CORS / allowedOrigins** includes `https://<app>.eldertree.local` if browser-facing API
+- [ ] Flux reconcile (or wait for interval):
+
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+flux reconcile source git flux-system -n flux-system
+flux reconcile kustomization flux-system -n flux-system --timeout=5m
+```
+
+### B. Mac / LAN routing (same PR when LAN-facing)
+
+- [ ] Add host to **`docs/eldertree-local-services.yaml`**
+- [ ] Add line to **`docs/eldertree-local-hosts-block.txt`**
+- [ ] Add line to **`scripts/add-services-to-hosts.sh`**
+- [ ] Add Caddy block to **`scripts/Caddyfile`** (copy `elder.eldertree.local` stanza; change hostname)
+- [ ] If using hosts-only: `sudo ./scripts/add-services-to-hosts.sh` on Mac
+- [ ] If using Caddy: reload Caddy after editing Caddyfile
+
+### C. Verify (automated)
+
+```bash
+cd pi-fleet
+
+# 1. Repo files in sync (no cluster needed)
+./scripts/check-local-routing-registry.sh
+
+# 2. End-to-end (cluster + Pi-hole + Mac)
+export KUBECONFIG=~/.kube/config-eldertree
+./scripts/verify-service-routing.sh --host <app>.eldertree.local
+```
+
+**Interpretation:**
+
+| Failed check | Likely fix |
+|--------------|------------|
+| No Ingress | GitOps not applied; Flux stuck; wrong namespace |
+| No endpoints | Image pull, crash loop, wrong selector |
+| Certificate not Ready | cert-manager issuer, DNS-01/CA config |
+| Pi-hole NXDOMAIN | external-dns annotation; external-dns logs |
+| Traefik NodePort OK, Mac curl fail | hosts/Caddy/DNS on Mac |
+| Mac 503, Traefik 503 | Backend down (not a routing issue) |
+| Missing from Caddyfile | Run registry sync; add stanza |
+
+Cluster-only debug (bypasses Mac):
+
+```bash
+curl -sk --resolve "<app>.eldertree.local:443:192.168.2.101" https://<app>.eldertree.local/
+```
+
+### D. Optional but recommended
+
+- [ ] **Blackbox** probe in `helm/monitoring-stack/values.yaml` (`blackbox-https-ca` for `*.eldertree.local`)
+- [ ] **Control Center** catalog in `elder` if the app should appear on the topology ([`ONBOARDING_APP_OBSERVABILITY.md`](ONBOARDING_APP_OBSERVABILITY.md) + Elder `COMPONENT_TARGETS`)
+- [ ] **Public URL** only if needed: Cloudflare Tunnel rule in `terraform/cloudflare.tf` (separate from LAN path)
+
+---
+
+## Public vs LAN
+
+| Access | Mechanism | Verify with |
+|--------|-----------|-------------|
+| **LAN / Tailscale** | Traefik + Pi-hole + hosts/Caddy | `verify-service-routing.sh` |
+| **Public HTTPS** | Cloudflare Tunnel → Traefik ClusterIP | Blackbox `blackbox-https` job; browser off-LAN |
+
+Do not assume LAN routing implies public URL or vice versa.
+
+---
+
+## Helm (`eldertree-app`) example
+
+```yaml
+ingress:
+  web:
+    host: myapp.eldertree.local
+    service: myapp-web
+    port: 8080
+    tls:
+      secretName: myapp-tls
+      certManager: true
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: myapp.eldertree.local
+```
+
+Then complete section **B** and run **C**.
+
+---
+
+## When something else breaks after a routing change
+
+1. Run **`./scripts/verify-service-routing.sh --all-local`** — find regressions across all services
+2. Run **`./scripts/check-local-routing-registry.sh`** — catch files out of sync
+3. Check **`flux get kustomization flux-system`** — one bad manifest blocks everything
+4. Prefer **additive** PRs (new host in all sync files) over editing shared Traefik middleware unless intentional
+
+---
+
+## Quick reference
+
+```bash
+# Registry sync only
+./scripts/check-local-routing-registry.sh --fix-hints
+
+# One new service after deploy
+./scripts/verify-service-routing.sh --host myapp.eldertree.local
+
+# Full regression sweep (e.g. after Caddy/hosts bulk edit)
+./scripts/verify-service-routing.sh --all-local
+```
+
+Memory: `ollie/memory/pifleet_service_routing_onboarding.md`

--- a/docs/SERVICES_REFERENCE.md
+++ b/docs/SERVICES_REFERENCE.md
@@ -204,12 +204,15 @@ DNS for `canopy.eldertree.xyz` is a **CNAME to the eldertree tunnel** (`cloudfla
 | Property         | Value                                                                 |
 | ---------------- | --------------------------------------------------------------------- |
 | **Local URL**    | `https://elder.eldertree.local`                                       |
+| **Control Center** | `https://control.eldertree.local` (live topology + health SPA)      |
 | **Swagger Docs** | `https://elder.eldertree.local/docs`                                  |
 | **Namespace**    | `openclaw`                                                            |
 | **API Port**     | 8006                                                                  |
-| **Role**         | Cluster ops, code, GitHub, LLM orchestrator, META (upgrade/version)   |
+| **Role**         | Cluster ops, code, GitHub, LLM orchestrator, META (upgrade/version), Control Center host |
+| **Public health API** | `GET /api/public/cluster/health` (no key; LAN/Tailscale)         |
 | **Credentials**  | Stored in Vault: `secret/elder/*`                                     |
 | **GitHub App**   | Install at org level (raolivei) — see [elder/README.md](../elder/README.md#github-app-setup) |
+| **Docs**         | [CONTROL_CENTER.md](CONTROL_CENTER.md) · [elder PUBLIC_CLUSTER_API](https://github.com/raolivei/elder/blob/main/docs/PUBLIC_CLUSTER_API.md) |
 
 ---
 

--- a/docs/eldertree-local-hosts-block.txt
+++ b/docs/eldertree-local-hosts-block.txt
@@ -15,6 +15,9 @@ TRAEFIK_LB_IP  pushgateway.eldertree.local
 TRAEFIK_LB_IP  flux.eldertree.local
 TRAEFIK_LB_IP  alertmanager.eldertree.local
 TRAEFIK_LB_IP  docs.eldertree.local
+TRAEFIK_LB_IP  audio.eldertree.local
+TRAEFIK_LB_IP  dex.eldertree.local
+TRAEFIK_LB_IP  openclaw.eldertree.local
 TRAEFIK_LB_IP  elder.eldertree.local
 TRAEFIK_LB_IP  control.eldertree.local
 TRAEFIK_LB_IP  journey.eldertree.local

--- a/docs/eldertree-local-services.yaml
+++ b/docs/eldertree-local-services.yaml
@@ -1,0 +1,65 @@
+# Eldertree local routing registry
+#
+# Single source of truth for *.eldertree.local hostnames that must resolve on
+# Rafael's Mac (Pi-hole DNS and/or /etc/hosts + optional Caddy).
+#
+# When onboarding a new LAN-facing service:
+#   1. Add the host here first
+#   2. Wire Ingress in Git (HelmRelease / Ingress manifest)
+#   3. Run: ./scripts/check-local-routing-registry.sh
+#   4. After deploy: ./scripts/verify-service-routing.sh --host <host>
+#
+# See docs/ONBOARDING_APP_ROUTING.md
+
+version: 1
+
+# Pi-hole is primary DNS on LAN; Mac may also use /etc/hosts or Caddy (see TAILSCALE.md)
+pihole_ip: "192.168.2.201"
+
+services:
+  - host: vault.eldertree.local
+    description: Vault UI
+  - host: grafana.eldertree.local
+    description: Grafana
+    blackbox_ca: true
+  - host: prometheus.eldertree.local
+    description: Prometheus UI
+    blackbox_ca: true
+  - host: alertmanager.eldertree.local
+    description: Alertmanager
+    blackbox_ca: true
+  - host: pihole.eldertree.local
+    description: Pi-hole admin
+  - host: flux.eldertree.local
+    description: Flux UI
+  - host: pushgateway.eldertree.local
+    description: Prometheus pushgateway
+  - host: docs.eldertree.local
+    description: Eldertree docs (cluster ingress)
+  - host: audio.eldertree.local
+    description: Eldertree docs audio ingress
+  - host: dex.eldertree.local
+    description: Dex OIDC
+  - host: openclaw.eldertree.local
+    description: OpenClaw Web UI
+  - host: elder.eldertree.local
+    description: Elder API / Swagger
+  - host: control.eldertree.local
+    description: Eldertree Control Center
+    blackbox_ca: true
+  - host: canopy.eldertree.local
+    description: Canopy finance app
+  - host: swimto.eldertree.local
+    description: SwimTO web
+  - host: pitanga.eldertree.local
+    description: Pitanga website
+  - host: journey.eldertree.local
+    description: Journey app
+  - host: nima.eldertree.local
+    description: Nima app
+
+# Files that must list every host above (enforced by check-local-routing-registry.sh)
+sync_targets:
+  - docs/eldertree-local-hosts-block.txt
+  - scripts/add-services-to-hosts.sh
+  - scripts/Caddyfile

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -4,7 +4,7 @@
 # This proxies *.eldertree.local to the k3s cluster via Traefik NodePort
 # Allows accessing services without specifying port numbers
 #
-# Only includes DEPLOYED services (as of 2026-01-16)
+# Only includes DEPLOYED services — keep in sync with docs/eldertree-local-services.yaml
 
 {
     # Use local self-signed certs
@@ -107,6 +107,105 @@ control.eldertree.local {
             tls_insecure_skip_verify
         }
         header_up Host control.eldertree.local
+    }
+}
+
+# Eldertree Control Center (Elder SPA + /api/public/cluster/*)
+control.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host control.eldertree.local
+    }
+}
+
+# OpenClaw (AI assistant Web UI)
+openclaw.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host openclaw.eldertree.local
+    }
+}
+
+# Alertmanager
+alertmanager.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host alertmanager.eldertree.local
+    }
+}
+
+# Eldertree docs (runbook ingress)
+docs.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host docs.eldertree.local
+    }
+}
+
+# Dex OIDC
+dex.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host dex.eldertree.local
+    }
+}
+
+# Eldertree docs audio ingress
+audio.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host audio.eldertree.local
+    }
+}
+
+# Canopy (personal finance)
+canopy.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host canopy.eldertree.local
+    }
+}
+
+# Journey (career pathfinder)
+journey.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host journey.eldertree.local
+    }
+}
+
+# Nima (ML learning)
+nima.eldertree.local {
+    tls internal
+    reverse_proxy https://192.168.2.101:32474 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+        header_up Host nima.eldertree.local
     }
 }
 

--- a/scripts/add-services-to-hosts.sh
+++ b/scripts/add-services-to-hosts.sh
@@ -54,9 +54,14 @@ $INGRESS_IP  grafana.eldertree.local
 $INGRESS_IP  prometheus.eldertree.local
 $INGRESS_IP  pihole.eldertree.local
 $INGRESS_IP  flux.eldertree.local
+$INGRESS_IP  pushgateway.eldertree.local
+$INGRESS_IP  alertmanager.eldertree.local
 $INGRESS_IP  elder.eldertree.local
 $INGRESS_IP  control.eldertree.local
+$INGRESS_IP  openclaw.eldertree.local
 $INGRESS_IP  docs.eldertree.local
+$INGRESS_IP  audio.eldertree.local
+$INGRESS_IP  dex.eldertree.local
 
 # Applications
 $INGRESS_IP  canopy.eldertree.local

--- a/scripts/check-local-routing-registry.sh
+++ b/scripts/check-local-routing-registry.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Verify local routing files include every host in docs/eldertree-local-services.yaml
+#
+# Usage (from pi-fleet repo root):
+#   ./scripts/check-local-routing-registry.sh
+#   ./scripts/check-local-routing-registry.sh --fix-hints
+#
+# Exit 0 if all hosts appear in sync_targets; exit 1 if any missing.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGISTRY="${ROOT}/docs/eldertree-local-services.yaml"
+HINTS=false
+
+if [[ "${1:-}" == "--fix-hints" ]]; then
+  HINTS=true
+fi
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "ERROR: registry not found: $REGISTRY" >&2
+  exit 1
+fi
+
+mapfile -t HOSTS < <(
+  awk '/^  - host: / { print $3 }' "$REGISTRY" | sort -u
+)
+
+if [[ ${#HOSTS[@]} -eq 0 ]]; then
+  echo "ERROR: no hosts parsed from $REGISTRY" >&2
+  exit 1
+fi
+
+mapfile -t TARGETS < <(
+  awk '/^  - / && !/^  - host:/ { gsub(/^  - /, ""); print }' "$REGISTRY"
+)
+
+FAIL=0
+echo "=== Local routing registry sync (${#HOSTS[@]} hosts) ==="
+echo ""
+
+for target_rel in "${TARGETS[@]}"; do
+  target="${ROOT}/${target_rel}"
+  if [[ ! -f "$target" ]]; then
+    echo "FAIL  missing file: $target_rel"
+    FAIL=1
+    continue
+  fi
+  missing=()
+  for host in "${HOSTS[@]}"; do
+    if ! grep -qF "$host" "$target"; then
+      missing+=("$host")
+    fi
+  done
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "OK    $target_rel"
+  else
+    echo "FAIL  $target_rel — missing ${#missing[@]} host(s):"
+    for h in "${missing[@]}"; do
+      echo "        - $h"
+    done
+    FAIL=1
+  fi
+done
+
+if [[ $FAIL -ne 0 ]]; then
+  echo ""
+  if $HINTS; then
+    cat <<'EOF'
+
+Fix hints:
+  1. Add missing hosts to docs/eldertree-local-hosts-block.txt (TRAEFIK_LB_IP line)
+  2. Add to scripts/add-services-to-hosts.sh (inside Eldertree block)
+  3. Copy a Caddy block from scripts/Caddyfile (elder.eldertree.local template)
+  4. Re-run: ./scripts/check-local-routing-registry.sh
+
+Onboarding guide: docs/ONBOARDING_APP_ROUTING.md
+EOF
+  fi
+  exit 1
+fi
+
+# Optional: hosts in sync files but not in registry (drift) — warnings only
+set +e
+for target_rel in "${TARGETS[@]}"; do
+  target="${ROOT}/${target_rel}"
+  [[ -f "$target" ]] || continue
+  while IFS= read -r line; do
+    [[ "$line" =~ \.eldertree\.local ]] || continue
+    host=$(echo "$line" | grep -oE '[a-z0-9.-]+\.eldertree\.local' | head -1 || true)
+    [[ -z "$host" ]] && continue
+    [[ "$host" =~ ^node-[0-9]\.eldertree\.local$ ]] && continue
+    found=false
+    for h in "${HOSTS[@]}"; do
+      [[ "$h" == "$host" ]] && found=true && break
+    done
+    if ! $found; then
+      echo "WARN  $host in $target_rel but not in registry — add to eldertree-local-services.yaml"
+    fi
+  done < <(grep -E '\.eldertree\.local' "$target" 2>/dev/null || true)
+done
+set -e
+
+echo "All registry hosts present in sync files."
+exit 0

--- a/scripts/verify-service-routing.sh
+++ b/scripts/verify-service-routing.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# End-to-end routing verification for a *.eldertree.local service (cluster → DNS → Mac).
+#
+# Usage:
+#   export KUBECONFIG=~/.kube/config-eldertree
+#   ./scripts/verify-service-routing.sh --host swimto.eldertree.local
+#   ./scripts/verify-service-routing.sh --all-local          # every host in registry
+#   ./scripts/verify-service-routing.sh --host foo.eldertree.local --skip-mac
+#
+# Checks (in order):
+#   1. Ingress exists with host rule and backend Service has endpoints
+#   2. TLS Certificate Ready (if Ingress uses TLS)
+#   3. external-dns hostname annotation present
+#   4. Pi-hole DNS resolves host
+#   5. Traefik NodePort HTTPS with Host header (bypasses Mac DNS/Caddy)
+#   6. Mac path: curl https://host (uses your DNS + optional Caddy)
+#   7. Registry sync (check-local-routing-registry.sh) for that host
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGISTRY="${ROOT}/docs/eldertree-local-services.yaml"
+PIHOLE_IP="${PIHOLE_IP:-192.168.2.201}"
+TRAEFIK_HTTPS_NODEPORT="${TRAEFIK_HTTPS_NODEPORT:-}"
+TRAEFIK_NODE_IP="${TRAEFIK_NODE_IP:-192.168.2.101}"
+SKIP_MAC=false
+HOST=""
+ALL_LOCAL=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host) HOST="$2"; shift 2 ;;
+    --all-local) ALL_LOCAL=true; shift ;;
+    --skip-mac) SKIP_MAC=true; shift ;;
+    --pihole-ip) PIHOLE_IP="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}  $*"; }
+fail() { echo -e "${RED}FAIL${NC}  $*"; FAILURES=$((FAILURES + 1)); }
+warn() { echo -e "${YELLOW}WARN${NC}  $*"; }
+
+FAILURES=0
+
+require_kubectl() {
+  if ! command -v kubectl >/dev/null 2>&1; then
+    fail "kubectl not found"
+    return 1
+  fi
+  if ! kubectl cluster-info >/dev/null 2>&1; then
+    fail "kubectl cannot reach cluster (KUBECONFIG=${KUBECONFIG:-unset})"
+    return 1
+  fi
+  return 0
+}
+
+detect_traefik_nodeport() {
+  if [[ -n "$TRAEFIK_HTTPS_NODEPORT" ]]; then
+    return 0
+  fi
+  local port
+  port=$(kubectl get svc traefik -n kube-system -o jsonpath='{.spec.ports[?(@.name=="websecure")].nodePort}' 2>/dev/null || true)
+  if [[ -z "$port" ]]; then
+    port=$(kubectl get svc traefik -n kube-system -o jsonpath='{.spec.ports[?(@.port==443)].nodePort}' 2>/dev/null || true)
+  fi
+  if [[ -n "$port" ]]; then
+    TRAEFIK_HTTPS_NODEPORT="$port"
+    pass "Traefik HTTPS NodePort: $port (via $TRAEFIK_NODE_IP)"
+  else
+    warn "Could not detect Traefik websecure NodePort; set TRAEFIK_HTTPS_NODEPORT"
+  fi
+}
+
+verify_host() {
+  local host="$1"
+  echo ""
+  echo "========== $host =========="
+
+  # --- Cluster: find ingress ---
+  local ing_line ns ing_name svc port endpoints
+  ing_line=$(kubectl get ingress -A -o json 2>/dev/null | python3 -c "
+import json, sys
+host = sys.argv[1]
+data = json.load(sys.stdin)
+for item in data.get('items', []):
+    for rule in item.get('spec', {}).get('rules', []) or []:
+        if rule.get('host') == host:
+            ns = item['metadata']['namespace']
+            name = item['metadata']['name']
+            paths = rule.get('http', {}).get('paths', [])
+            svc = port = None
+            if paths:
+                be = paths[0].get('backend', {}).get('service', {})
+                svc = be.get('name')
+                port = be.get('port', {}).get('number')
+            print(f'{ns}\t{name}\t{svc or \"-\"}\t{port or \"-\"}')
+            sys.exit(0)
+sys.exit(1)
+" "$host" 2>/dev/null || true)
+
+  if [[ -z "$ing_line" ]]; then
+    fail "No Ingress with host $host in cluster"
+    return
+  fi
+  IFS=$'\t' read -r ns ing_name svc port <<< "$ing_line"
+  pass "Ingress $ns/$ing_name → Service $svc:$port"
+
+  # --- Endpoints ---
+  if [[ "$svc" != "-" ]]; then
+    endpoints=$(kubectl get endpoints "$svc" -n "$ns" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)
+    if [[ -n "$endpoints" ]]; then
+      pass "Service endpoints: $endpoints"
+    else
+      fail "Service $ns/$svc has no ready endpoints (503 at Traefik)"
+    fi
+  fi
+
+  # --- TLS certificate ---
+  local tls_secret
+  tls_secret=$(kubectl get ingress "$ing_name" -n "$ns" -o jsonpath='{.spec.tls[0].secretName}' 2>/dev/null || true)
+  if [[ -n "$tls_secret" ]]; then
+    local cert_ready
+    cert_ready=$(kubectl get certificate -n "$ns" -o json 2>/dev/null | python3 -c "
+import json, sys
+secret = sys.argv[1]
+for c in json.load(sys.stdin).get('items', []):
+    if c.get('spec', {}).get('secretName') == secret:
+        for cond in c.get('status', {}).get('conditions', []):
+            if cond.get('type') == 'Ready':
+                print(cond.get('status', 'Unknown'))
+                sys.exit(0)
+print('Missing')
+" "$tls_secret" 2>/dev/null || echo "Missing")
+    if [[ "$cert_ready" == "True" ]]; then
+      pass "Certificate for $tls_secret Ready"
+    else
+      fail "Certificate for $tls_secret not Ready ($cert_ready)"
+    fi
+  else
+    warn "Ingress has no TLS block"
+  fi
+
+  # --- external-dns annotation ---
+  local edns
+  edns=$(kubectl get ingress "$ing_name" -n "$ns" -o jsonpath='{.metadata.annotations.external-dns\.alpha\.kubernetes\.io/hostname}' 2>/dev/null || true)
+  if [[ -n "$edns" ]]; then
+    pass "external-dns hostname: $edns"
+  else
+    warn "Missing external-dns.alpha.kubernetes.io/hostname (Pi-hole may not auto-update)"
+  fi
+
+  # --- Pi-hole DNS ---
+  if command -v dig >/dev/null 2>&1; then
+    local dns_answer
+    dns_answer=$(dig +short "@${PIHOLE_IP}" "$host" A 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+    if [[ -n "$dns_answer" ]]; then
+      pass "Pi-hole ($PIHOLE_IP) → $dns_answer"
+    else
+      fail "Pi-hole does not resolve $host (check external-dns / BIND sidecar; is $PIHOLE_IP reachable?)"
+    fi
+  else
+    warn "dig not installed — skip Pi-hole check"
+  fi
+
+  # --- Traefik direct (cluster path) ---
+  if [[ -n "$TRAEFIK_HTTPS_NODEPORT" ]]; then
+    local code
+    code=$(curl -sk --connect-timeout 8 -o /dev/null -w "%{http_code}" \
+      --resolve "${host}:443:${TRAEFIK_NODE_IP}" \
+      "https://${host}/" 2>/dev/null || echo "000")
+    if [[ "$code" =~ ^(200|301|302|401|403|404)$ ]]; then
+      pass "Traefik NodePort HTTPS → HTTP $code (routing works; 401/403 may be expected)"
+    elif [[ "$code" == "503" ]]; then
+      fail "Traefik NodePort → HTTP 503 (no backend — check pod/endpoints)"
+    elif [[ "$code" == "000" ]]; then
+      fail "Traefik NodePort curl failed (network/firewall/NodePort)"
+    else
+      warn "Traefik NodePort → HTTP $code (investigate)"
+    fi
+  fi
+
+  # --- Mac path (DNS + optional Caddy) ---
+  if ! $SKIP_MAC; then
+    local mac_code
+    mac_code=$(curl -sk --connect-timeout 8 -o /dev/null -w "%{http_code}" "https://${host}/" 2>/dev/null || echo "000")
+    if [[ "$mac_code" =~ ^(200|301|302|401|403|404)$ ]]; then
+      pass "Mac curl https://$host → HTTP $mac_code"
+    elif [[ "$mac_code" == "503" ]]; then
+      fail "Mac curl → HTTP 503 (Caddy/hosts/DNS wrong, or backend down)"
+    elif [[ "$mac_code" == "000" ]]; then
+      fail "Mac curl failed — DNS/hosts/Caddy not wired (see check-local-routing-registry.sh)"
+    else
+      warn "Mac curl → HTTP $mac_code"
+    fi
+  fi
+
+  # --- Registry file sync for this host ---
+  local missing_files=()
+  for f in docs/eldertree-local-hosts-block.txt scripts/add-services-to-hosts.sh scripts/Caddyfile; do
+    if ! grep -qF "$host" "${ROOT}/$f" 2>/dev/null; then
+      missing_files+=("$f")
+    fi
+  done
+  if [[ ${#missing_files[@]} -eq 0 ]]; then
+    pass "Host listed in hosts block, add-services-to-hosts.sh, and Caddyfile"
+  else
+    fail "Host missing from: ${missing_files[*]}"
+  fi
+}
+
+mapfile -t ALL_HOSTS < <(awk '/^  - host: / { print $3 }' "$REGISTRY" 2>/dev/null | sort -u)
+
+if $ALL_LOCAL; then
+  require_kubectl || exit 1
+  detect_traefik_nodeport
+  for h in "${ALL_HOSTS[@]}"; do
+    verify_host "$h"
+  done
+elif [[ -n "$HOST" ]]; then
+  require_kubectl || exit 1
+  detect_traefik_nodeport
+  verify_host "$HOST"
+else
+  echo "Usage: $0 --host <fqdn> | --all-local" >&2
+  exit 2
+fi
+
+echo ""
+if [[ $FAILURES -eq 0 ]]; then
+  echo -e "${GREEN}All checks passed.${NC}"
+  exit 0
+else
+  echo -e "${RED}$FAILURES check(s) failed.${NC} See docs/ONBOARDING_APP_ROUTING.md"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add end-to-end LAN routing onboarding (`ONBOARDING_APP_ROUTING.md`, `eldertree-local-services.yaml`)
- Add verify scripts: `check-local-routing-registry.sh`, `verify-service-routing.sh`
- Add `CONTROL_CENTER.md` for `control.eldertree.local` ops
- Sync local Caddy/hosts block with full service registry; update InfraOPS agent and cross-links

## Test plan
- [ ] `bash -n scripts/check-local-routing-registry.sh scripts/verify-service-routing.sh`
- [ ] `./scripts/check-local-routing-registry.sh` passes on Mac with updated Caddyfile
- [ ] `./scripts/verify-service-routing.sh --help` runs
- [ ] Docs links resolve in GitHub preview


Made with [Cursor](https://cursor.com)