### PR TITLE
fix: cluster warnings — Traefik VIP routing and reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Fixed
+
+- **Caddy / CoreDNS LAN routing** — `scripts/Caddyfile` proxies to Traefik kube-vip `192.168.2.200:443` (was `192.168.2.101:32474`, which hit Pi-hole on 443). CoreDNS custom hosts add `control.eldertree.local` and `elder.eldertree.local`.
+- **Traefik VIP / Pi-hole 403** — Stop exposing HTTPS (443) on the Pi-hole LoadBalancer Service (`exposeHttpsOnLoadBalancer: false`) so K3s `svclb-traefik` can bind hostPort 443 on `192.168.2.200`; fixes all `*.eldertree.local` URLs (including Control Center) returning Pi-hole HTML.
+- **Control Center routing** — Add `docs/eldertree-local-services.yaml`, `check-local-routing-registry.sh`, `verify-service-routing.sh`, and `docs/ONBOARDING_APP_ROUTING.md` / `CONTROL_CENTER.md`; sync hosts registry for `control.eldertree.local`.
+
+### Fixed
+
+- **Ollie GitOps** — Vendor `helm/ollie` chart into pi-fleet (Flux `HelmRelease` path `./helm/ollie`); ExternalSecrets use `ClusterSecretStore` `vault` (not `vault-backend`).
+- **Node scheduling tier reconciler** — Replace distroless `rancher/kubectl` (no `/bin/sh`) with `debian:bookworm-slim` + downloaded `kubectl` for the CronJob shell script.
+
 ### Changed
 
 - **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.0` (Control Center SPA + `/api/public/cluster/health`); ImageRepository tracks `elder` instead of legacy `grove`. Ingress `control.eldertree.local` → Elder service.

--- a/clusters/eldertree/core-infrastructure/coredns-custom.yaml
+++ b/clusters/eldertree/core-infrastructure/coredns-custom.yaml
@@ -22,6 +22,8 @@ data:
         192.168.2.200 pitanga.eldertree.local
         192.168.2.200 docs.eldertree.local
         192.168.2.200 openclaw.eldertree.local
+        192.168.2.200 control.eldertree.local
+        192.168.2.200 elder.eldertree.local
         fallthrough
       }
     }

--- a/clusters/eldertree/core-infrastructure/node-scheduling/reconciler-cronjob.yaml
+++ b/clusters/eldertree/core-infrastructure/node-scheduling/reconciler-cronjob.yaml
@@ -31,16 +31,23 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: kubectl
-              image: rancher/kubectl:v1.33.5
+              # rancher/kubectl is distroless (no /bin/sh); install kubectl in a shell image.
+              image: debian:bookworm-slim
               imagePullPolicy: IfNotPresent
               envFrom:
                 - configMapRef:
                     name: node-scheduling-config
               command:
-                - /bin/sh
+                - /bin/bash
                 - -ec
                 - |
                   set -e
+                  apt-get update -qq
+                  apt-get install -y -qq curl ca-certificates
+                  curl -sLO "https://dl.k8s.io/release/v1.35.0/bin/linux/arm64/kubectl"
+                  chmod +x kubectl
+                  export PATH="$PWD:$PATH"
+
                   TAINT="${TAINT_KEY}=${TAINT_VALUE}:${TAINT_EFFECT}"
 
                   kubectl label node "${UNSTABLE_NODE}" "${LABEL_KEY}=unstable" --overwrite
@@ -55,8 +62,8 @@ spec:
                   echo "node scheduling tiers reconciled"
               resources:
                 requests:
-                  cpu: 10m
-                  memory: 32Mi
+                  cpu: 50m
+                  memory: 128Mi
                 limits:
-                  cpu: 100m
-                  memory: 64Mi
+                  cpu: 500m
+                  memory: 256Mi

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -136,7 +136,7 @@ spec:
       elder:
         image:
           repository: ghcr.io/raolivei/elder
-          tag: v0.3.2 # {"$imagepolicy": "openclaw:elder:tag"}
+          tag: v0.3.3 # {"$imagepolicy": "openclaw:elder:tag"}
           pullPolicy: Always
         port: 8006
         servicePort: 8000

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -1,7 +1,8 @@
 # Caddyfile for Eldertree Local Proxy
 # Run with: sudo caddy run --config ~/WORKSPACE/raolivei/pi-fleet/scripts/Caddyfile
 #
-# This proxies *.eldertree.local to the k3s cluster via Traefik NodePort
+# This proxies *.eldertree.local to the k3s cluster via kube-vip Traefik VIP.
+# Use 192.168.2.200:443 — NOT a node LAN IP (node-1 often hits Pi-hole on 443).
 # Allows accessing services without specifying port numbers
 #
 # Only includes DEPLOYED services (as of 2026-01-16)
@@ -14,7 +15,7 @@
 # Grafana (observability)
 grafana.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -25,7 +26,7 @@ grafana.eldertree.local {
 # Vault (secrets management)
 vault.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -36,7 +37,7 @@ vault.eldertree.local {
 # Prometheus (metrics)
 prometheus.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -47,7 +48,7 @@ prometheus.eldertree.local {
 # SwimTO (Toronto pool schedules)
 swimto.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -58,7 +59,7 @@ swimto.eldertree.local {
 # Pitanga (website)
 pitanga.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -69,7 +70,7 @@ pitanga.eldertree.local {
 # Flux UI (GitOps dashboard)
 flux.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -80,7 +81,7 @@ flux.eldertree.local {
 # Pushgateway (metrics push endpoint)
 pushgateway.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -91,7 +92,7 @@ pushgateway.eldertree.local {
 # Elder (AI agent API + Swagger docs)
 elder.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -102,7 +103,7 @@ elder.eldertree.local {
 # Eldertree Control Center (Elder SPA + /api/public/cluster/*)
 control.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }
@@ -113,7 +114,7 @@ control.eldertree.local {
 # Pi-hole (DNS admin - may not work via ingress)
 pihole.eldertree.local {
     tls internal
-    reverse_proxy https://192.168.2.101:32474 {
+    reverse_proxy https://192.168.2.200:443 {
         transport http {
             tls_insecure_skip_verify
         }


### PR DESCRIPTION
## Summary
- Point Caddy at kube-vip Traefik `192.168.2.200:443` (fixes Pi-hole 403 on Control Center when using Caddy).
- Add `control.eldertree.local` and `elder.eldertree.local` to CoreDNS custom hosts for in-cluster OIDC.
- Fix node-scheduling tier reconciler CronJob image (debian + kubectl; rancher/kubectl is distroless).

## Test plan
- [x] Cluster: no unhealthy non-job pods after reconcile
- [x] `curl -sk --resolve control.eldertree.local:443:192.168.2.200 https://control.eldertree.local/api/public/cluster/health` → 200
- [ ] After merge: `flux reconcile kustomization flux-system`
- [ ] Rafael: update Mac `/etc/hosts` to `192.168.2.200` for `*.eldertree.local`
- [ ] Optional: `ansible-playbook playbooks/disable-k3s-servicelb.yml` to stop svclb recreation


Made with [Cursor](https://cursor.com)