### PR TITLE
fix: vendor Ollie Helm chart and tier reconciler CronJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Added
+
+- **Ollie Helm chart** — Vendor `helm/ollie` from the [ollie](https://github.com/raolivei/ollie) repo so Flux `HelmRelease` path `./helm/ollie` resolves (fixes `InvalidChartReference`).
+
+### Fixed
+
+- **Ollie ExternalSecrets** — `ClusterSecretStore` ref `vault-backend` → `vault` (matches live cluster store name).
+- **Node scheduling tier reconciler** — Replace distroless `rancher/kubectl` (no `/bin/sh`, StartError) with `debian:bookworm-slim` + downloaded `kubectl v1.35.0` arm64; bump job memory for apt/curl install.
+
 ### Changed
 
 - **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.0` (Control Center SPA + `/api/public/cluster/health`); ImageRepository tracks `elder` instead of legacy `grove`. Ingress `control.eldertree.local` → Elder service.

--- a/clusters/eldertree/core-infrastructure/node-scheduling/reconciler-cronjob.yaml
+++ b/clusters/eldertree/core-infrastructure/node-scheduling/reconciler-cronjob.yaml
@@ -31,16 +31,23 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: kubectl
-              image: rancher/kubectl:v1.33.5
+              # rancher/kubectl is distroless (no /bin/sh); install kubectl in a shell image.
+              image: debian:bookworm-slim
               imagePullPolicy: IfNotPresent
               envFrom:
                 - configMapRef:
                     name: node-scheduling-config
               command:
-                - /bin/sh
+                - /bin/bash
                 - -ec
                 - |
                   set -e
+                  apt-get update -qq
+                  apt-get install -y -qq curl ca-certificates
+                  curl -sLO "https://dl.k8s.io/release/v1.35.0/bin/linux/arm64/kubectl"
+                  chmod +x kubectl
+                  export PATH="$PWD:$PATH"
+
                   TAINT="${TAINT_KEY}=${TAINT_VALUE}:${TAINT_EFFECT}"
 
                   kubectl label node "${UNSTABLE_NODE}" "${LABEL_KEY}=unstable" --overwrite
@@ -55,8 +62,8 @@ spec:
                   echo "node scheduling tiers reconciled"
               resources:
                 requests:
-                  cpu: 10m
-                  memory: 32Mi
+                  cpu: 50m
+                  memory: 128Mi
                 limits:
-                  cpu: 100m
-                  memory: 64Mi
+                  cpu: 500m
+                  memory: 256Mi

--- a/clusters/eldertree/ollie/ghcr-secret-external.yaml
+++ b/clusters/eldertree/ollie/ghcr-secret-external.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-backend
+    name: vault
     kind: ClusterSecretStore
   target:
     name: ghcr-secret

--- a/clusters/eldertree/ollie/ollie-secrets-external.yaml
+++ b/clusters/eldertree/ollie/ollie-secrets-external.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-backend
+    name: vault
     kind: ClusterSecretStore
   target:
     name: ollie-secrets

--- a/helm/ollie/Chart.yaml
+++ b/helm/ollie/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: ollie
+description: A Helm chart for Ollie Local AI
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/helm/ollie/templates/cronjob-training.yaml
+++ b/helm/ollie/templates/cronjob-training.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.training.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-training
+  labels:
+    app: ollie
+    component: training
+spec:
+  schedule: "{{ .Values.training.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: ollie
+            component: training
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: training
+              image: "{{ .Values.training.image.repository }}:{{ .Values.training.image.tag }}"
+              imagePullPolicy: {{ .Values.training.image.pullPolicy }}
+              env:
+                - name: DATA_DIR
+                  value: "/data"
+                - name: OLLAMA_HOST
+                  value: "http://ollama:11434"
+                - name: BASE_MODEL_PATH
+                  value: "/data/models/Llama-3.1-8B"
+              volumeMounts:
+                - name: data-storage
+                  mountPath: /data
+              resources:
+                {{- toYaml .Values.training.resources | nindent 16 }}
+          volumes:
+            - name: data-storage
+              persistentVolumeClaim:
+                claimName: {{ .Release.Name }}-data-pvc
+{{- end }}

--- a/helm/ollie/templates/deployment-core.yaml
+++ b/helm/ollie/templates/deployment-core.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-core
+  labels:
+    app: ollie
+    component: core
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollie
+      component: core
+  template:
+    metadata:
+      labels:
+        app: ollie
+        component: core
+    spec:
+      containers:
+        - name: core
+          image: "{{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}"
+          imagePullPolicy: {{ .Values.core.image.pullPolicy }}
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATA_DIR
+              value: "/data"
+            - name: WORKSPACE_ROOT
+              value: {{ .Values.workspace.root | quote }}
+            - name: WORKSPACE_DOCS_DIR
+              value: {{ .Values.workspace.docsDir | quote }}
+            - name: AUDIO_ENABLED
+              value: {{ .Values.audio.enabled | quote }}
+            - name: OLLAMA_URL
+              {{- if .Values.ollama.deployOnCluster }}
+              value: "http://ollama:11434"
+              {{- else }}
+              value: {{ .Values.ollama.externalUrl | quote }}
+              {{- end }}
+            - name: OLLAMA_MODEL
+              value: {{ .Values.core.env.ollamaModel | quote }}
+            - name: ELDER_URL
+              value: {{ .Values.elder.url | quote }}
+            - name: ELDER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: elder-api-key
+                  optional: true
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: openrouter-api-key
+                  optional: true
+            - name: LOCAL_WORKSPACE_TOOLS
+              value: "false"
+            {{- if .Values.audio.enabled }}
+            - name: WHISPER_URL
+              value: "http://whisper:8000"
+            - name: TTS_URL
+              value: "http://tts:8000"
+            {{- end }}
+          volumeMounts:
+            - name: data-storage
+              mountPath: /data
+            - name: workspace-docs
+              mountPath: {{ .Values.workspace.root }}
+              readOnly: true
+          resources:
+            {{- toYaml .Values.core.resources | nindent 12 }}
+      volumes:
+        - name: data-storage
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data-pvc
+        - name: workspace-docs
+          hostPath:
+            path: {{ .Values.workspace.hostPath | default "/mnt/workspace" }}
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: core
+  {{- if .Values.monitoring.enabled }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.monitoring.port | quote }}
+    prometheus.io/path: {{ .Values.monitoring.path | quote }}
+  {{- end }}
+spec:
+  selector:
+    app: ollie
+    component: core
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/helm/ollie/templates/deployment-ollama.yaml
+++ b/helm/ollie/templates/deployment-ollama.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.ollama.deployOnCluster }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ollama
+  labels:
+    app: ollie
+    component: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollie
+      component: ollama
+  template:
+    metadata:
+      labels:
+        app: ollie
+        component: ollama
+    spec:
+      containers:
+        - name: ollama
+          image: "{{ .Values.ollama.image.repository }}:{{ .Values.ollama.image.tag }}"
+          imagePullPolicy: {{ .Values.ollama.image.pullPolicy }}
+          ports:
+            - containerPort: 11434
+          volumeMounts:
+            - name: ollama-storage
+              mountPath: /root/.ollama
+            - name: data-storage
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.ollama.resources | nindent 12 }}
+      volumes:
+        - name: ollama-storage
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-ollama-pvc
+        - name: data-storage
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-ollama-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.global.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.ollama.storage.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+spec:
+  selector:
+    app: ollie
+    component: ollama
+  ports:
+    - protocol: TCP
+      port: 11434
+      targetPort: 11434
+{{- end }}

--- a/helm/ollie/templates/deployment-tts.yaml
+++ b/helm/ollie/templates/deployment-tts.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.audio.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-tts
+  labels:
+    app: ollie
+    component: tts
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollie
+      component: tts
+  template:
+    metadata:
+      labels:
+        app: ollie
+        component: tts
+    spec:
+      containers:
+        - name: tts
+          image: "{{ .Values.tts.image.repository }}:{{ .Values.tts.image.tag }}"
+          imagePullPolicy: {{ .Values.tts.image.pullPolicy }}
+          ports:
+            - containerPort: 8000
+          resources:
+            {{- toYaml .Values.tts.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tts
+spec:
+  selector:
+    app: ollie
+    component: tts
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+{{- end }}
+

--- a/helm/ollie/templates/deployment-ui.yaml
+++ b/helm/ollie/templates/deployment-ui.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ui
+  labels:
+    app: ollie
+    component: ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollie
+      component: ui
+  template:
+    metadata:
+      labels:
+        app: ollie
+        component: ui
+    spec:
+      containers:
+        - name: ui
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - containerPort: 8501
+          env:
+            - name: OLLIE_API_URL
+              value: "http://core:8000"
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+spec:
+  type: {{ .Values.ui.service.type }}
+  selector:
+    app: ollie
+    component: ui
+  ports:
+    - protocol: TCP
+      port: 8501
+      targetPort: 8501
+      {{- if eq .Values.ui.service.type "NodePort" }}
+      nodePort: {{ .Values.ui.service.nodePort }}
+      {{- end }}
+

--- a/helm/ollie/templates/deployment-whisper.yaml
+++ b/helm/ollie/templates/deployment-whisper.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.audio.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-whisper
+  labels:
+    app: ollie
+    component: whisper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollie
+      component: whisper
+  template:
+    metadata:
+      labels:
+        app: ollie
+        component: whisper
+    spec:
+      containers:
+        - name: whisper
+          image: "{{ .Values.whisper.image.repository }}:{{ .Values.whisper.image.tag }}"
+          imagePullPolicy: {{ .Values.whisper.image.pullPolicy }}
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: data-storage
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.whisper.resources | nindent 12 }}
+      volumes:
+        - name: data-storage
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whisper
+spec:
+  selector:
+    app: ollie
+    component: whisper
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+{{- end }}

--- a/helm/ollie/templates/pvc-data.yaml
+++ b/helm/ollie/templates/pvc-data.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-data-pvc
+  labels:
+    app: ollie
+    component: storage
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode }}
+  storageClassName: {{ .Values.global.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}

--- a/helm/ollie/values.yaml
+++ b/helm/ollie/values.yaml
@@ -1,0 +1,123 @@
+global:
+  storageClass: "local-path"
+
+# Feature flags
+audio:
+  enabled: false
+
+# Mac Ollama via Tailscale (override per environment)
+ollama:
+  externalUrl: "http://host.docker.internal:11434"
+  deployOnCluster: false
+  image:
+    repository: ghcr.io/raolivei/ollie-ollama
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "4Gi"
+      cpu: "1000m"
+    limits:
+      memory: "6Gi"
+      cpu: "4000m"
+  storage:
+    size: "10Gi"
+
+elder:
+  url: "http://elder.openclaw.svc.cluster.local:8000"
+
+monitoring:
+  enabled: true
+  port: "8000"
+  path: "/metrics"
+
+workspace:
+  root: "/workspace"
+  docsDir: "/workspace"
+  hostPath: "/mnt/workspace"
+
+persistence:
+  data:
+    size: "20Gi"
+    accessMode: ReadWriteOnce
+
+whisper:
+  image:
+    repository: ghcr.io/raolivei/ollie-whisper
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "2000m"
+
+tts:
+  image:
+    repository: ghcr.io/raolivei/ollie-tts
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "2000m"
+
+core:
+  image:
+    repository: ghcr.io/raolivei/ollie-core
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "200m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+  env:
+    ollamaModel: "qwen2.5:7b"
+    audioEnabled: false
+
+ui:
+  image:
+    repository: ghcr.io/raolivei/ollie-ui
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  service:
+    type: NodePort
+    port: 8501
+    nodePort: 30001
+
+frontend:
+  enabled: true
+  image:
+    repository: ghcr.io/raolivei/ollie-frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+
+training:
+  enabled: true
+  image:
+    repository: ghcr.io/raolivei/ollie-training
+    tag: latest
+    pullPolicy: IfNotPresent
+  schedule: "0 2 * * *"
+  resources:
+    requests:
+      memory: "2Gi"
+      cpu: "1000m"
+    limits:
+      memory: "4Gi"
+      cpu: "4000m"


### PR DESCRIPTION
## Summary
- **Vendor `helm/ollie`** from the ollie repo so Flux `HelmRelease` path `./helm/ollie` resolves (fixes `InvalidChartReference` / Ollie HelmRelease Not Ready)
- **ExternalSecrets** — `ClusterSecretStore` ref `vault-backend` → `vault` (matches live cluster)
- **Tier reconciler CronJob** — replace distroless `rancher/kubectl` (no `/bin/sh`, StartError) with `debian:bookworm-slim` + downloaded `kubectl v1.35.0` arm64

Complements [#206](https://github.com/raolivei/pi-fleet/pull/206) (Traefik VIP / Pi-hole / Caddy routing) — scoped separately for faster merge.

## Prerequisites (post-merge)
- Vault path `secret/pi-fleet/ollie` must exist for `ollie-secrets` ExternalSecret sync
- `flux reconcile helmrelease ollie -n ollie` after merge
- Confirm tier reconciler: `kubectl create job --from=cronjob/node-scheduling-tier-reconciler tier-test-manual -n kube-system`

## Test plan
- [ ] `helm template ollie helm/ollie --namespace ollie` renders without error
- [ ] Flux dry-run: `flux build kustomization flux-system --path ./clusters/eldertree`
- [ ] After merge: `flux get helmrelease ollie -n ollie` → Ready
- [ ] After merge: tier reconciler manual job → Succeeded


Made with [Cursor](https://cursor.com)