### PR TITLE
feat: Control Center control.eldertree.xyz and elder v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Added
+
+- **Control Center public** — `control.eldertree.xyz` Cloudflare Tunnel ingress rule + DNS CNAME; OpenClaw `control-center-public` ingress with `*.eldertree.xyz` origin cert (ExternalSecret).
+
+### Changed
+
+- **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.5` (incident feed, topology layout, health fixes).
+
 ### Fixed
+
+- **Pi-hole (Helm 0.2.2)** — Remove zero-byte `gravity.db` init stub; postStart waits for web UI then runs `pihole -g` when db missing/empty. Metrics sidecar `ghcr.io/mosher-labs/pihole6-exporter` (Pi-hole v6 session auth).
 
 - **Caddy / CoreDNS LAN routing** — `scripts/Caddyfile` proxies to Traefik kube-vip `192.168.2.200:443` (was `192.168.2.101:32474`, which hit Pi-hole on 443). CoreDNS custom hosts add `control.eldertree.local` and `elder.eldertree.local`.
 - **Traefik VIP / Pi-hole 403** — Stop exposing HTTPS (443) on the Pi-hole LoadBalancer Service (`exposeHttpsOnLoadBalancer: false`) so K3s `svclb-traefik` can bind hostPort 443 on `192.168.2.200`; fixes all `*.eldertree.local` URLs (including Control Center) returning Pi-hole HTML.

--- a/clusters/eldertree/openclaw/control-cloudflare-origin-cert-external.yaml
+++ b/clusters/eldertree/openclaw/control-cloudflare-origin-cert-external.yaml
@@ -1,0 +1,35 @@
+---
+# ExternalSecret for *.eldertree.xyz Cloudflare Origin Certificate
+# Reuses the wildcard cert stored in Vault (shared across all *.eldertree.xyz subdomains)
+# Used by Control Center (control.eldertree.xyz).eldertree.xyz for public HTTPS access
+#
+# Vault path: secret/swimto/cloudflare-origin-cert-eldertree
+# (Wildcard cert covers *.eldertree.xyz and eldertree.xyz)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: control-cloudflare-origin-cert
+  namespace: openclaw
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: control-cloudflare-origin-tls
+    # Merge updates existing secret (e.g. if created manually); avoids "secret already exists" error
+    creationPolicy: Merge
+    template:
+      type: kubernetes.io/tls
+      data:
+        tls.crt: "{{ .certificate }}"
+        tls.key: "{{ .privatekey }}"
+  data:
+    - secretKey: certificate
+      remoteRef:
+        key: secret/swimto/cloudflare-origin-cert-eldertree
+        property: certificate
+    - secretKey: privatekey
+      remoteRef:
+        key: secret/swimto/cloudflare-origin-cert-eldertree
+        property: private-key

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -136,7 +136,7 @@ spec:
       elder:
         image:
           repository: ghcr.io/raolivei/elder
-          tag: v0.3.3 # {"$imagepolicy": "openclaw:elder:tag"}
+          tag: v0.3.5 # {"$imagepolicy": "openclaw:elder:tag"}
           pullPolicy: Always
         port: 8006
         servicePort: 8000
@@ -262,3 +262,13 @@ spec:
           certManager: true
         annotations:
           external-dns.alpha.kubernetes.io/hostname: control.eldertree.local
+
+      # --- Public (control.eldertree.xyz) ---
+      control-center-public:
+        host: control.eldertree.xyz
+        service: elder
+        port: 8000
+        tls:
+          secretName: control-cloudflare-origin-tls
+        annotations:
+          external-dns.alpha.kubernetes.io/exclude: "true"

--- a/clusters/eldertree/openclaw/kustomization.yaml
+++ b/clusters/eldertree/openclaw/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - elder-image-repo.yaml
   - elder-image-policy.yaml
   - elder-image-update.yaml
+  - control-cloudflare-origin-cert-external.yaml

--- a/helm/pi-hole/Chart.yaml
+++ b/helm/pi-hole/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pi-hole
 description: A custom Helm chart for Pi-hole with BIND backend
 type: application
-version: 0.2.0
+version: 0.2.2
 appVersion: "latest"

--- a/helm/pi-hole/templates/deployment.yaml
+++ b/helm/pi-hole/templates/deployment.yaml
@@ -41,11 +41,10 @@ spec:
               TSIG_SECRET=$(cat /etc/bind-tsig/tsig-secret)
               sed "s|TSIG_SECRET_PLACEHOLDER|${TSIG_SECRET}|g" /etc/named/named.conf > /var/named/named.conf
               chmod 644 /var/named/named.conf
-              # Create empty gravity.db stub so Pi-hole skips auto-gravity on first start
-              # (gravity.db is rebuilt by postStart hook once Pi-hole is ready)
+              # Remove corrupt zero-byte gravity.db (legacy init stub) so Pi-hole can rebuild it
               mkdir -p /etc/pihole
-              if [ ! -f /etc/pihole/gravity.db ]; then
-                touch /etc/pihole/gravity.db
+              if [ -f /etc/pihole/gravity.db ] && [ ! -s /etc/pihole/gravity.db ]; then
+                rm -f /etc/pihole/gravity.db
               fi
           volumeMounts:
             - name: bind-config
@@ -115,8 +114,27 @@ spec:
           lifecycle:
             postStart:
               exec:
-                # Rebuild gravity in background after startup; runs non-blocking
-                command: ["/bin/sh", "-c", "sleep 30 && pihole -g &"]
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    if [ -n "${WEBPASSWORD:-}" ]; then
+                      pihole setpassword "$WEBPASSWORD" >/dev/null 2>&1 || true
+                    fi
+                    (
+                      for i in $(seq 1 60); do
+                        curl -sf http://127.0.0.1/admin/ >/dev/null && break
+                        sleep 5
+                      done
+                      if [ ! -s /etc/pihole/gravity.db ]; then
+                        rm -f /etc/pihole/gravity.db
+                        cp /etc/resolv.conf /tmp/resolv.conf.bak
+                        printf "nameserver 1.1.1.1\nnameserver 1.0.0.1\n" > /etc/resolv.conf
+                        pihole -g
+                        mv /tmp/resolv.conf.bak /etc/resolv.conf
+                        pihole reloadlists
+                      fi
+                    ) &
           resources:
             {{- toYaml .Values.resources.pihole | nindent 12 }}
           livenessProbe:
@@ -166,23 +184,26 @@ spec:
         - name: exporter
           image: "{{ .Values.image.exporter.repository }}:{{ .Values.image.exporter.tag }}"
           imagePullPolicy: {{ .Values.image.exporter.pullPolicy }}
+          args:
+            - "-H"
+            - "127.0.0.1"
+            - "--pihole-port"
+            - "80"
+            - "--protocol"
+            - "http"
+            - "-p"
+            - "{{ .Values.service.metricsPort }}"
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
               protocol: TCP
           env:
-            - name: PIHOLE_HOSTNAME
-              value: "127.0.0.1"
-            - name: PIHOLE_PORT
-              value: "80"
             - name: PIHOLE_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: pihole-secrets
                   key: webpassword
                   optional: true
-            - name: PORT
-              value: "{{ .Values.service.metricsPort }}"
           resources:
             {{- toYaml .Values.resources.exporter | nindent 12 }}
           livenessProbe:

--- a/helm/pi-hole/values.yaml
+++ b/helm/pi-hole/values.yaml
@@ -12,7 +12,8 @@ image:
     tag: latest
     pullPolicy: IfNotPresent
   exporter:
-    repository: ekofr/pihole-exporter
+    # Pi-hole v6 session auth; ekofr/pihole-exporter returns 401 on v6 API
+    repository: ghcr.io/mosher-labs/pihole6-exporter
     tag: latest
     pullPolicy: IfNotPresent
 

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -400,6 +400,14 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "eldertree" {
       service  = "http://10.43.23.214:80"
     }
 
+
+    # Control Center (Elder ops console)
+    ingress_rule {
+      hostname = "control.eldertree.xyz"
+      path     = "/"
+      service  = "http://10.43.23.214:80"
+    }
+
     # Catch-all rule (must be last)
     ingress_rule {
       service = "http_status:404"
@@ -418,6 +426,20 @@ resource "cloudflare_record" "canopy_eldertree_xyz_tunnel" {
   proxied         = true
   allow_overwrite = true
   comment         = "canopy.eldertree.xyz - managed by Terraform via Cloudflare Tunnel"
+}
+
+
+# DNS CNAME record for control.eldertree.xyz pointing to tunnel
+resource "cloudflare_record" "control_eldertree_xyz_tunnel" {
+  count           = local.cloudflare_enabled && var.cloudflare_account_id != "" && var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id         = data.cloudflare_zone.eldertree_xyz[0].id
+  name            = "control"
+  content         = "${cloudflare_zero_trust_tunnel_cloudflared.eldertree[0].id}.cfargotunnel.com"
+  type            = "CNAME"
+  ttl             = 1
+  proxied         = true
+  allow_overwrite = true
+  comment         = "control.eldertree.xyz - Eldertree Control Center via Cloudflare Tunnel"
 }
 
 # DNS CNAME record for swimto.eldertree.xyz pointing to tunnel


### PR DESCRIPTION
## Summary
- Elder OpenClaw image `v0.3.5` + public ingress `control.eldertree.xyz` (wildcard origin cert ExternalSecret)
- Cloudflare Tunnel ingress rule + CNAME `control` → tunnel
- Pi-hole chart 0.2.2: gravity.db fix, pihole6-exporter

## Test plan
- [ ] `check-local-routing-registry.sh` (passed locally)
- [ ] Terraform apply via CI on merge
- [ ] Flux reconcile openclaw + pihole
- [ ] `curl https://control.eldertree.xyz/api/public/cluster/health`
- [ ] `verify-service-routing.sh --host control.eldertree.local`


Made with [Cursor](https://cursor.com)