### PR TITLE
fix: Control Center origin TLS ExternalSecret Owner policy

### DIFF
--- a/clusters/eldertree/openclaw/control-cloudflare-origin-cert-external.yaml
+++ b/clusters/eldertree/openclaw/control-cloudflare-origin-cert-external.yaml
@@ -18,7 +18,7 @@ spec:
   target:
     name: control-cloudflare-origin-tls
     # Merge updates existing secret (e.g. if created manually); avoids "secret already exists" error
-    creationPolicy: Merge
+    creationPolicy: Owner
     template:
       type: kubernetes.io/tls
       data:


### PR DESCRIPTION
ESO Merge requires pre-existing secret; Owner creates control-cloudflare-origin-tls.

Made with [Cursor](https://cursor.com)