### PR TITLE
fix: control.eldertree.xyz DNS reconcile in Terraform CI

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -170,6 +170,16 @@ jobs:
             echo "::notice title=Terraform plan::$PLAN_LINE"
           fi
 
+      - name: Reconcile control.eldertree.xyz DNS (tunnel CNAME)
+        if: |
+          steps.plan.outcome == 'success' &&
+          (
+            (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.apply == 'true')
+          )
+        working-directory: .
+        run: bash scripts/cloudflare-reconcile-control-dns.sh
+
       - name: Terraform Apply
         id: apply
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Pi-hole HelmRelease** — `strategy: Recreate` and 20m upgrade timeout (RollingUpdate dual-pod upgrades caused Helm deadline exceeded).
+- **control.eldertree.xyz DNS** — `scripts/cloudflare-reconcile-control-dns.sh` removes stale `control` A records before Terraform apply; runs in `terraform.yml` on apply.
+
 - **Pi-hole (Helm 0.2.2)** — Remove zero-byte `gravity.db` init stub; postStart waits for web UI then runs `pihole -g` when db missing/empty. Metrics sidecar `ghcr.io/mosher-labs/pihole6-exporter` (Pi-hole v6 session auth).
 
 - **Caddy / CoreDNS LAN routing** — `scripts/Caddyfile` proxies to Traefik kube-vip `192.168.2.200:443` (was `192.168.2.101:32474`, which hit Pi-hole on 443). CoreDNS custom hosts add `control.eldertree.local` and `elder.eldertree.local`.

--- a/clusters/eldertree/dns-services/pihole/helmrelease.yaml
+++ b/clusters/eldertree/dns-services/pihole/helmrelease.yaml
@@ -21,11 +21,12 @@ spec:
   upgrade:
     remediation:
       retries: 3
-    timeout: 15m
+    timeout: 20m
   values:
     persistence:
       enabled: false
-    strategy: RollingUpdate
+    # Recreate avoids two pods during upgrade (RollingUpdate + maxSurge timed out Helm).
+    strategy: Recreate
     service:
       type: LoadBalancer
       loadBalancerClass: null

--- a/scripts/cloudflare-reconcile-control-dns.sh
+++ b/scripts/cloudflare-reconcile-control-dns.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Remove stale Cloudflare DNS records for control.eldertree.xyz so Terraform can
+# create the tunnel CNAME (cloudflare_record.control_eldertree_xyz_tunnel).
+#
+# Fails when external-dns or manual A records exist with the same name but
+# different type/target than the tunnel CNAME.
+#
+# Usage (secrets from Vault via run-terraform.sh env):
+#   source scripts/lib/load-terraform-secrets-from-vault.sh
+#   export TF_VAR_cloudflare_api_token TF_VAR_cloudflare_zone_id
+#   ./scripts/cloudflare-reconcile-control-dns.sh
+#
+# CI: run before terraform apply when control CNAME fails with allow_overwrite mismatch.
+
+set -euo pipefail
+
+TOKEN="${TF_VAR_cloudflare_api_token:-${CLOUDFLARE_API_TOKEN:-}}"
+ZONE_ID="${TF_VAR_cloudflare_zone_id:-${CLOUDFLARE_ZONE_ID:-}}"
+NAME="control"
+
+if [[ -z "$TOKEN" || -z "$ZONE_ID" ]]; then
+  echo "Need TF_VAR_cloudflare_api_token and TF_VAR_cloudflare_zone_id" >&2
+  exit 1
+fi
+
+api() {
+  curl -sfS -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "$@"
+}
+
+echo "Listing Cloudflare records for ${NAME}.eldertree.xyz (zone ${ZONE_ID})..."
+RECORDS="$(api "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${NAME}.eldertree.xyz")"
+echo "$RECORDS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if not data.get('success'):
+    print('API error:', data, file=sys.stderr)
+    sys.exit(1)
+for r in data.get('result', []):
+    print(f\"{r['id']}\t{r['type']}\t{r.get('content','')}\")
+"
+
+while IFS=$'\t' read -r id rtype content; do
+  [[ -z "$id" ]] && continue
+  if [[ "$rtype" == "CNAME" && "$content" == *".cfargotunnel.com" ]]; then
+    echo "OK: tunnel CNAME already present ($id)"
+    continue
+  fi
+  echo "Deleting ${rtype} record $id (${content})..."
+  api -X DELETE "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${id}" >/dev/null
+  echo "Deleted."
+done < <(echo "$RECORDS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for r in data.get('result', []):
+    print(r['id'], r['type'], r.get('content',''), sep='\t')
+")
+
+echo "Done. Re-run: cd terraform && terraform apply"


### PR DESCRIPTION
## Summary
- Adds `scripts/cloudflare-reconcile-control-dns.sh` to delete stale `control` A records before Terraform creates the tunnel CNAME
- Wires reconcile step into `.github/workflows/terraform.yml` immediately before `terraform apply` on main (no manual `terraform apply`)
- Pi-hole HelmRelease: `Recreate` strategy + 20m upgrade timeout (fixes Helm deadline exceeded on RollingUpdate)

## Test plan
- [ ] Merge to main → Terraform workflow runs plan + reconcile + apply
- [ ] `dig control.eldertree.xyz` shows tunnel CNAME (not 10.0.0.x)
- [ ] `curl -skI https://control.eldertree.xyz` returns 200
- [ ] Flux reconciles pi-hole HelmRelease successfully

Made with [Cursor](https://cursor.com)