### PR TITLE
chore: deploy Elder Control Center v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
-- **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.5` (incident feed, topology layout, health fixes).
+- **Elder (Control Center)** — Image `ghcr.io/raolivei/elder:v0.3.6` (kube-vip DaemonSet health, topology layout variants).
 
 ### Fixed
 

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -136,7 +136,7 @@ spec:
       elder:
         image:
           repository: ghcr.io/raolivei/elder
-          tag: v0.3.5 # {"$imagepolicy": "openclaw:elder:tag"}
+          tag: v0.3.6 # {"$imagepolicy": "openclaw:elder:tag"}
           pullPolicy: Always
         port: 8006
         servicePort: 8000


### PR DESCRIPTION
## Summary
- Bump OpenClaw HelmRelease `elder` image to `ghcr.io/raolivei/elder:v0.3.6`.
- Includes kube-vip DaemonSet health in `/api/public/cluster/health` (fixes false red in topology).

## Test plan
- [ ] `ghcr.io/raolivei/elder:v0.3.6` exists on GHCR (elder CI on main)
- [ ] After Flux reconcile: Elder pod image `v0.3.6`
- [ ] `curl -sk https://control.eldertree.local/api/public/cluster/health | jq '.components[] | select(.id=="kube_vip")'`

Depends on: https://github.com/raolivei/elder/pull/16 (merged)


Made with [Cursor](https://cursor.com)