### PR TITLE
fix(ollie): update images to v0.4.5 and re-enable frontend

### DIFF
--- a/clusters/eldertree/ollie/helmrelease.yaml
+++ b/clusters/eldertree/ollie/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
     core:
       image:
         repository: ghcr.io/raolivei/ollie-core
-        tag: v0.4.0
+        tag: v0.4.5
         pullPolicy: Always
       resources:
         requests:
@@ -42,8 +42,8 @@ spec:
           memory: "1Gi"
           cpu: "1000m"
     frontend:
-      enabled: false
+      enabled: true
       image:
         repository: ghcr.io/raolivei/ollie-frontend
-        tag: v0.2.0
+        tag: v0.4.5
         pullPolicy: Always


### PR DESCRIPTION
## Summary
Updates Ollie images to v0.4.5 and re-enables frontend deployment.

## Changes
- ✅ Update `ollie-core` from v0.4.0 → v0.4.5
- ✅ Update `ollie-frontend` from v0.2.0 → v0.4.5
- ✅ Re-enable frontend deployment (`enabled: false` → `true`)

## Context
- Frontend was temporarily disabled in commit 80ca069 due to missing images
- Images are now built via GitHub Actions workflow run [26927006880](https://github.com/raolivei/ollie/actions/runs/26927006880)
- `ollie-frontend:v0.4.5` is already successfully built
- `ollie-core:v0.4.5` is currently building (expected to complete soon)

## Fixes
- Resolves ImagePullBackOff errors in ollie namespace
- Restores full Ollie functionality with UI

## Test Plan
- [ ] Wait for ollie-core build completion
- [ ] FluxCD reconciles successfully
- [ ] Both ollie-core and ollie-frontend pods start
- [ ] No ImagePullBackOff errors
- [ ] Ollie UI accessible (if ingress configured)