### PR TITLE
chore: reduce Vault auto-unseal frequency to hourly

### DIFF
--- a/clusters/eldertree/secrets-management/vault/auto-unseal-cronjob.yaml
+++ b/clusters/eldertree/secrets-management/vault/auto-unseal-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-# Runs every 5 minutes, checks each vault pod, and unseals any that are sealed.
+# Runs every hour, checks each vault pod, and unseals any that are sealed.
 # Uses unseal keys from the existing vault-unseal-keys secret.
 # No external dependencies — entirely in-cluster.
 apiVersion: batch/v1
@@ -8,7 +8,7 @@ metadata:
   name: vault-auto-unseal
   namespace: vault
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary

Reduce Vault auto-unseal CronJob frequency from every 5 minutes to every hour.

## Changes

- Schedule: `*/5 * * * *` → `0 * * * *` (hourly, on the hour)
- Update comment to reflect new frequency

## Rationale

**Why reduce:**
- Reduces job noise (12 jobs/hour → 1 job/hour)
- Lower resource churn
- 1-hour max wait for auto-unseal is acceptable
- Current: 3 successful jobs shown in history every 15 min

**Why not remove:**
- Vault seals on pod restart (security by design)
- Manual unseal of 3 pods is tedious
- Maintains self-hosted approach (no AWS KMS dependency)
- vault-1 has 25 restarts over 2.5 days, needs auto-unseal

**Trade-offs:**
- Max 1-hour wait for auto-unseal after restart vs 5 min
- Manual unseal still available: `./scripts/operations/unseal-vault.sh`

## Impact

- Lower resource usage: 288 jobs/day → 24 jobs/day
- Vault may stay sealed up to 1 hour after restart (vs 5 min)
- No functional change to Vault operations

## Testing

After merge:
- Current CronJob will be updated in-place
- Next run: top of the hour
- Verify: `kubectl get cronjob -n vault vault-auto-unseal`

---

**Alternative considered:** AWS KMS auto-unseal (~-3/month) rejected to maintain self-hosted independence.