### PR TITLE
fix: correct ARC controllerServiceAccount name for ollie-runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Fixed
+
+- **ARC runners stuck Pending** — `ollie-runners` HelmRelease `controllerServiceAccount.name` was `arc-controller-gha-rs-controller`, but the controller HelmRelease is named `arc-controller-arc-controller`, so its actual SA is `arc-controller-arc-controller-gha-rs-controller`. The mismatch made the chart-rendered `ollie-eldertree-gha-rs-manager` RoleBinding bind a non-existent SA, so the controller could not create JIT secrets/pods (runners stuck Pending) or clean up finished runners (stuck Deleting). Corrected the SA name so the manager RoleBinding binds the real controller SA.
+
 ### Added
 
 - **Control Center public** — `control.eldertree.xyz` Cloudflare Tunnel ingress rule + DNS CNAME; OpenClaw `control-center-public` ingress with `*.eldertree.xyz` origin cert (ExternalSecret).

--- a/clusters/eldertree/arc-runners/ollie-runner-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/ollie-runner-helmrelease.yaml
@@ -65,6 +65,11 @@ spec:
                 memory: "4Gi"
 
     # Controller service account reference
+    # Must match the controller's actual SA: the controller HelmRelease is named
+    # `arc-controller-arc-controller`, so the chart renders the SA with the doubled
+    # prefix. A mismatch here makes the rendered gha-rs-manager RoleBinding bind a
+    # non-existent SA, so the controller cannot create JIT secrets/pods (runners
+    # stay Pending) or clean up finished runners (stuck Deleting).
     controllerServiceAccount:
       namespace: arc-controller
-      name: arc-controller-gha-rs-controller
+      name: arc-controller-arc-controller-gha-rs-controller


### PR DESCRIPTION
## Summary
- Self-hosted ARC runners for `raolivei/ollie` were stuck **Pending** (and finished runners stuck **Deleting**).
- Root cause: the `ollie-runners` HelmRelease set `controllerServiceAccount.name: arc-controller-gha-rs-controller`, but the controller HelmRelease is named `arc-controller-arc-controller`, so its real ServiceAccount is `arc-controller-arc-controller-gha-rs-controller`.
- The `gha-runner-scale-set` chart renders the `ollie-eldertree-gha-rs-manager` RoleBinding from that value, so it bound a **non-existent SA** → controller `forbidden` to create JIT secrets/pods or delete finished runners.

## Fix
- Set `controllerServiceAccount.name` to the real SA `arc-controller-arc-controller-gha-rs-controller` (matches the existing controller-secrets ClusterRoleBinding).

## Verification (already done live)
- Patched the live RoleBinding subject → controller `can-i create/delete secrets,pods` = yes.
- Dispatched `build-publish.yaml` in `raolivei/ollie`: runner set scaled **0 → 3**, pods registered (263/264/265), runners connected to GitHub and picked up jobs.

## Test plan
- [ ] Flux reconciles `ollie-runners` HelmRelease; rendered `ollie-eldertree-gha-rs-manager` RoleBinding subject = `arc-controller-arc-controller-gha-rs-controller`
- [ ] New ollie workflow run: runners scale from zero and jobs complete

Made with [Cursor](https://cursor.com)