### PR TITLE
infra: ARC org-wide runners for all raolivei repos

### DIFF
--- a/.github/workflows/build-openclaw-arm64.yml
+++ b/.github/workflows/build-openclaw-arm64.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,6 +1,7 @@
 # Terraform secrets: source of truth is Vault (secret/pi-fleet/terraform/*).
-# GitHub-hosted runners cannot reach vault.eldertree.local — repo secrets are synced via:
+# GitHub repo secrets are synced via:
 #   ./scripts/sync-github-terraform-secrets-from-vault.sh --app actions --app dependabot
+# CI runs on Eldertree self-hosted runners (runs-on: self-hosted).
 name: "Terraform"
 
 on:
@@ -52,7 +53,7 @@ env:
 jobs:
   terraform:
     name: "Terraform"
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: dev
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **ARC ollie-runners** — Register at org scope (`githubConfigUrl: https://github.com/raolivei`) so all org repos can use `runs-on: self-hosted` on the Eldertree scale set.
+- **pi-fleet CI** — Terraform and OpenClaw ARM64 build workflows use Eldertree self-hosted runners.
 - **Helm release names (cluster-wide)** — Set `releaseName: <metadata.name>` on all Eldertree HelmReleases so Flux no longer creates doubled releases (`openclaw-openclaw`, `canopy-canopy`, `observability-monitoring-stack`, etc.). See migration table in `FLUX_HELM_NAMING.md`.
 - **ARC HelmRepository** — Rename `arc-controller` → `arc-charts` in `flux-system` (serves both controller and scale-set OCI charts).
 - **ARC ClusterRole** — Rename `arc-controller-gha-rs-controller-secrets` → `arc-controller-secrets`.

--- a/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
     - name: arc-controller
       namespace: arc-controller
   values:
-    # GitHub Configuration
-    githubConfigUrl: "https://github.com/raolivei/ollie"
+    # GitHub Configuration — org-wide so all raolivei repos can use runs-on: self-hosted
+    githubConfigUrl: "https://github.com/raolivei"
     githubConfigSecret: ollie-runner-github-secret
 
     # Scaling configuration — 6 matches parallel jobs in ollie build-publish.yaml

--- a/docs/ARC_RUNNERS.md
+++ b/docs/ARC_RUNNERS.md
@@ -154,6 +154,12 @@ kubectl logs -n arc-runners <pod-name>
 
 ## Adding More Repos
 
+**Default (2026-06):** The `ollie-runners` scale set registers at **org** scope (`githubConfigUrl: https://github.com/raolivei`). Any repo in the org can use `runs-on: self-hosted` without a separate HelmRelease.
+
+**PAT requirement:** Vault secret `secret/eldertree/arc-runners/ollie` must be a token with permission to register **organization** self-hosted runners (classic: `admin:org` → `manage_runners:org`; or fine-grained org admin).
+
+**Per-repo scale sets (optional):** Only needed for isolated quotas, different secrets, or non-`raolivei` repos.
+
 1. Create ExternalSecret in `clusters/eldertree/arc-runners/`:
    ```yaml
    apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
## Summary
- Register `ollie-runners` at org scope (`githubConfigUrl: https://github.com/raolivei`) so any org repo can use `runs-on: self-hosted`.
- Move pi-fleet Terraform and OpenClaw ARM64 workflows to self-hosted.

## Prerequisites
- Vault PAT at `secret/eldertree/arc-runners/ollie` must allow **org** runner registration (`manage_runners:org`).

## Deploy order
1. Merge and Flux reconcile this PR first
2. Verify listener re-registers at org level (`kubectl get pods -n arc-runners`)
3. Then merge `github-workflows` self-hosted defaults PR

## Test plan
- [ ] Flux reconciles `ollie-runners` HelmRelease
- [ ] Listener pod healthy in `arc-runners`
- [ ] Dispatch a workflow in a non-ollie repo (e.g. pi-fleet-blog) and confirm runner pod provisions


Made with [Cursor](https://cursor.com)