### PR TITLE
fix: ARC ollie scope until org PAT

### DIFF
--- a/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
       namespace: arc-controller
   values:
     # GitHub Configuration — org-wide so all raolivei repos can use runs-on: self-hosted
-    githubConfigUrl: "https://github.com/raolivei"
+    githubConfigUrl: "https://github.com/raolivei/ollie"
     githubConfigSecret: ollie-runner-github-secret
 
     # Scaling configuration — 6 matches parallel jobs in ollie build-publish.yaml


### PR DESCRIPTION
Listener crash loop: 404 on org registration-token. Revert to repo scope until Vault PAT updated.

Made with [Cursor](https://cursor.com)