### PR TITLE
feat: org-wide ARC + PAT setup scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
+- **ARC org PAT setup** — [`scripts/operations/setup-arc-org-github-pat.sh`](scripts/operations/setup-arc-org-github-pat.sh) writes a `manage_runners:org` token to Vault before enabling org-wide scale set.
 - **Flux Helm naming guide** — [`docs/FLUX_HELM_NAMING.md`](docs/FLUX_HELM_NAMING.md): require explicit `releaseName` on all HelmReleases; migration map for doubled releases.
 - **Control Center public** — `control.eldertree.xyz` Cloudflare Tunnel ingress rule + DNS CNAME; OpenClaw `control-center-public` ingress with `*.eldertree.xyz` origin cert (ExternalSecret).
 - **Ollie Helm chart** — Vendor `helm/ollie` from the [ollie](https://github.com/raolivei/ollie) repo so Flux `HelmRelease` path `./helm/ollie` resolves (fixes `InvalidChartReference`).
 
 ### Changed
 
-- **ARC ollie-runners** — Register at org scope (`githubConfigUrl: https://github.com/raolivei`) so all org repos can use `runs-on: self-hosted` on the Eldertree scale set.
+- **ARC ollie-runners (pending #226)** — Register at org scope (`githubConfigUrl: https://github.com/raolivei`) after Vault PAT setup; until then cluster stays on `raolivei/ollie`.
 - **pi-fleet CI** — Terraform and OpenClaw ARM64 build workflows use Eldertree self-hosted runners.
 - **Helm release names (cluster-wide)** — Set `releaseName: <metadata.name>` on all Eldertree HelmReleases so Flux no longer creates doubled releases (`openclaw-openclaw`, `canopy-canopy`, `observability-monitoring-stack`, etc.). See migration table in `FLUX_HELM_NAMING.md`.
 - **ARC HelmRepository** — Rename `arc-controller` → `arc-charts` in `flux-system` (serves both controller and scale-set OCI charts).

--- a/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
     - name: arc-controller
       namespace: arc-controller
   values:
-    # GitHub Configuration — org-wide so all raolivei repos can use runs-on: self-hosted
-    githubConfigUrl: "https://github.com/raolivei/ollie"
+    # GitHub Configuration — org-wide (merge only after setup-arc-org-github-pat.sh)
+    githubConfigUrl: "https://github.com/raolivei"
     githubConfigSecret: ollie-runner-github-secret
 
     # Scaling configuration — 6 matches parallel jobs in ollie build-publish.yaml

--- a/scripts/operations/setup-arc-org-github-pat.sh
+++ b/scripts/operations/setup-arc-org-github-pat.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Store a GitHub PAT with org runner permissions in Vault for ARC org-wide scale set.
+# Requires: gh auth token with admin:org (manage_runners:org), kubectl + Eldertree cluster.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config-eldertree}"
+VAULT_PATH="secret/eldertree/arc-runners/ollie"
+
+echo "==> Checking gh token scopes..."
+if ! gh auth status -h github.com 2>&1 | grep -q 'admin:org'; then
+  echo "Missing admin:org scope. Run:"
+  echo "  gh auth refresh -h github.com -s admin:org"
+  exit 1
+fi
+
+GITHUB_TOKEN="$(gh auth token -h github.com)"
+echo "==> Verifying org registration-token API..."
+HTTP_CODE=$(curl -sS -o /tmp/arc-reg-token.json -w '%{http_code}' \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/orgs/raolivei/actions/runners/registration-token")
+if [[ "$HTTP_CODE" != "201" ]]; then
+  echo "Org registration-token failed (HTTP ${HTTP_CODE}):"
+  cat /tmp/arc-reg-token.json
+  exit 1
+fi
+echo "    OK — token can register org runners"
+
+VAULT_POD=$(kubectl get pods -n vault -l app.kubernetes.io/name=vault -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' | awk '{print $1}')
+VAULT_TOKEN=$(kubectl get secret vault-token -n external-secrets -o jsonpath='{.data.token}' | base64 -d)
+
+echo "==> Writing to Vault (${VAULT_PATH})..."
+kubectl exec -n vault "$VAULT_POD" -- \
+  env VAULT_ADDR=http://127.0.0.1:8200 "VAULT_TOKEN=${VAULT_TOKEN}" \
+  vault kv put "$VAULT_PATH" github_token="${GITHUB_TOKEN}"
+
+echo "==> Forcing ExternalSecret sync..."
+kubectl annotate externalsecret ollie-runner-github-secret -n arc-runners \
+  force-sync="$(date +%s)" --overwrite 2>/dev/null || \
+  kubectl delete secret ollie-runner-github-secret -n arc-runners --ignore-not-found
+
+sleep 5
+kubectl get secret ollie-runner-github-secret -n arc-runners >/dev/null
+echo "==> Secret synced. Restart listener:"
+echo "    flux reconcile helmrelease ollie-runners -n arc-runners"
+echo "    kubectl delete pod -n arc-controller -l actions.github.com/scale-set-name=ollie-eldertree"


### PR DESCRIPTION
## Summary
- Point `ollie-runners` at org scope (`githubConfigUrl: https://github.com/raolivei`) so all `raolivei` repos can use `runs-on: self-hosted`.
- Add `scripts/operations/setup-arc-org-github-pat.sh` to store a `manage_runners:org` token in Vault.

## Merge prerequisites (do not merge until all pass)
1. `gh auth refresh -h github.com -s admin:org` (complete device login)
2. `./scripts/operations/setup-arc-org-github-pat.sh`
3. Merge [github-workflows#18](https://github.com/raolivei/github-workflows/pull/18) (self-hosted defaults)

## Related
- Monitor + stress scripts: [#225](https://github.com/raolivei/pi-fleet/pull/225) (separate PR)

## Test plan
- [ ] Setup script returns HTTP 201 on org registration-token
- [ ] After merge + Flux reconcile: one healthy listener in `arc-controller`
- [ ] `gh api orgs/raolivei/actions/runners` lists online runners
- [ ] Parallel workflow dispatches scale to maxRunners (6)