### PR TITLE
fix: ARC runner scheduling — drop stable nodeSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 - **Control Center public** — `control.eldertree.xyz` Cloudflare Tunnel ingress rule + DNS CNAME; OpenClaw `control-center-public` ingress with `*.eldertree.xyz` origin cert (ExternalSecret).
 - **Ollie Helm chart** — Vendor `helm/ollie` from the [ollie](https://github.com/raolivei/ollie) repo so Flux `HelmRelease` path `./helm/ollie` resolves (fixes `InvalidChartReference`).
 
+### Fixed
+
+- **ARC runner pods Pending** — Drop `node-tier: stable` nodeSelector (node-1 was ~99% free but excluded while node-2 at 98% CPU requests and node-3 NotReady under load). Lower runner requests to 100m CPU / 512Mi.
+
 ### Changed
 
 - **ARC ollie-runners** — Repo-scoped (`githubConfigUrl: https://github.com/raolivei/ollie`); `maxRunners: 1` (serial `build-publish.yaml`). Org scope reverted — requires a GitHub Organization entity.

--- a/clusters/eldertree/arc-runners/canopy-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/canopy-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/elder-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/elder-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/eldertree-docs-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/eldertree-docs-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/github-workflows-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/github-workflows-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/nima-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/nima-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/northwaysignal-website-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/northwaysignal-website-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/ollie-runners-helmrelease.yaml
@@ -51,8 +51,6 @@ spec:
           workload-type: ci-cd
       spec:
         # CI on stable nodes only (node-2, node-3); node-1 is unstable tier
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         # Spread runners across nodes when possible (2 stable nodes → up to 3 each)
         affinity:
           podAntiAffinity:
@@ -74,18 +72,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/personal-website-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/personal-website-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/pi-fleet-blog-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/pi-fleet-blog-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/clusters/eldertree/arc-runners/swimto-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/swimto-runners-helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
-        nodeSelector:
-          eldertree.xyz/node-tier: stable
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,18 +62,19 @@ spec:
             image: ghcr.io/actions/actions-runner:latest
             command: ["/home/runner/run.sh"]
             resources:
-              # Lean requests (real CPU usage is low) so 4+ runners fit on stable nodes
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
               requests:
-                cpu: 250m
-                memory: 768Mi
+                cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
             resources:
               requests:
-                cpu: 100m
-                memory: 384Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
                 cpu: 1000m
                 memory: 1536Mi

--- a/docs/ARC_RUNNERS.md
+++ b/docs/ARC_RUNNERS.md
@@ -148,9 +148,9 @@ kubectl logs -n arc-runners <pod-name>
 - Runs on node-2 or node-3 only
 
 **Runners:**
-- No placement constraints
-- Kubernetes scheduler decides (natural spread across nodes)
-- Ephemeral workload, no affinity needed
+- Prefer stable nodes (node-2, node-3) via cluster scheduling; **no hard nodeSelector** — when stable nodes are saturated, runners may schedule on node-1 (unstable tier, `PreferNoSchedule` taint).
+- Pod anti-affinity spreads runners across hosts when possible.
+- Requests: **100m CPU + 512Mi** per runner container (~150m/pod with dind sidecar values) so multiple runners fit under heavy cluster request pressure.
 
 ## Adding More Repos
 
@@ -168,7 +168,7 @@ Each repo gets a HelmRelease with `githubConfigUrl: https://github.com/raolivei/
 
 2. Create HelmRelease in `clusters/eldertree/arc-runners/<slug>-runners-helmrelease.yaml` — copy an existing release and set unique `metadata.name`, `releaseName`, `runnerScaleSetName`, `githubConfigUrl`, and `maxRunners` (default `1`; `2` for repos with parallel docker-build jobs).
 
-   **Resource sizing (Pi 5 cluster):** Each runner pod is runner + DinD sidecar (~750m CPU / 1.5Gi requests). Pin to `node-tier: stable`. Cluster-wide budget: **4–6 concurrent DinD runners** across all scale sets.
+   **Resource sizing (Pi 5 cluster):** Each runner pod is runner + DinD (~100m+512Mi requests). No `node-tier: stable` nodeSelector — node-1 absorbs overflow when node-2/3 are full. Cluster-wide budget: **4–6 concurrent DinD runners** under normal load; avoid firing all scale sets at once (stress script).
 
 3. Update `clusters/eldertree/arc-runners/kustomization.yaml`
 4. Commit and push — Flux deploys automatically


### PR DESCRIPTION
## Summary
Canopy (and other) runner pods stuck Pending: node-2 at 98% CPU requests, node-3 NotReady under load, node-1 excluded by `node-tier: stable` nodeSelector despite being ~99% free.

- Remove `nodeSelector: eldertree.xyz/node-tier: stable` from all runner HelmReleases
- Lower requests to 100m CPU / 512Mi (runner) so scheduler can place pods

## Test plan
- [ ] Flux reconcile; pending canopy pods schedule on node-1 or node-2
- [ ] `kubectl get pods -n arc-runners` — Running count increases

Made with [Cursor](https://cursor.com)