### PR TITLE
fix: external-dns crash loop, ESO Vault paths, and Pi-hole arm64 exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Pi-hole exporter ImagePullBackOff (arm64)** — `ghcr.io/mosher-labs/pihole6-exporter` has no arm64 manifest; pod stayed 2/3 Ready with **empty Service endpoints**, breaking RFC2136 external-dns. Chart adds `exporter.enabled` (off on Eldertree until arm64 image exists).
+- **external-dns RFC2136 crash loop** — `EXTERNAL_DNS_RFC2136_HOST` pointed at stale Pi-hole ClusterIP `10.43.117.25`; updated to current `10.43.153.12` (`kubectl get svc -n pi-hole pi-hole`).
+- **ExternalSecret Vault path drift** — `ollie`, `personal-website`, and `pitanga` `ghcr-secret` now read `secret/canopy/ghcr-token` (same as swimto/canopy). `ollie-secrets` reads `secret/elder/api-key` and `secret/openclaw/openrouter` instead of missing `secret/pi-fleet/*` paths.
 - **Grafana/KEDA Prometheus DNS after Helm naming migration** — Grafana datasource, KEDA `serverAddress`, and pushgateway ingress pointed at removed `observability-monitoring-stack-prometheus-server`; updated to `monitoring-stack-prometheus-server`. monitoring-stack chart **0.2.15**.
 - **Ollie training CronJob ImagePullBackOff** — `ghcr.io/raolivei/ollie-training:latest` was never published (not in ollie `build-publish.yaml`). Disable `training.enabled` until the image is built and pushed.
 - **ARC runner pods Pending** — Drop `node-tier: stable` nodeSelector (node-1 was ~99% free but excluded while node-2 at 98% CPU requests and node-3 NotReady under load). Lower runner requests to 100m CPU / 512Mi.

--- a/clusters/eldertree/dns-services/external-dns/helmrelease.yaml
+++ b/clusters/eldertree/dns-services/external-dns/helmrelease.yaml
@@ -40,8 +40,8 @@ spec:
     env:
       - name: EXTERNAL_DNS_RFC2136_HOST
         # Use stable ClusterIP instead of hostname to avoid circular DNS dependency
-        # Verify with: kubectl get svc -n pihole pi-hole -o jsonpath='{.spec.clusterIP}'
-        value: "10.43.117.25"
+        # Verify with: kubectl get svc -n pi-hole pi-hole -o jsonpath='{.spec.clusterIP}'
+        value: "10.43.153.12"
       - name: EXTERNAL_DNS_RFC2136_PORT
         value: "5353"
       - name: EXTERNAL_DNS_RFC2136_ZONE

--- a/clusters/eldertree/dns-services/pi-hole/helmrelease.yaml
+++ b/clusters/eldertree/dns-services/pi-hole/helmrelease.yaml
@@ -24,6 +24,8 @@ spec:
       retries: 3
     timeout: 20m
   values:
+    exporter:
+      enabled: false
     persistence:
       enabled: false
     # Recreate avoids two pods during upgrade (RollingUpdate + maxSurge timed out Helm).

--- a/clusters/eldertree/ollie/ghcr-secret-external.yaml
+++ b/clusters/eldertree/ollie/ghcr-secret-external.yaml
@@ -10,24 +10,23 @@ spec:
     kind: ClusterSecretStore
   target:
     name: ghcr-secret
+    creationPolicy: Owner
     template:
       type: kubernetes.io/dockerconfigjson
+      engineVersion: v2
       data:
         .dockerconfigjson: |
           {
             "auths": {
               "ghcr.io": {
-                "username": "{{ .username }}",
-                "password": "{{ .password }}"
+                "username": "raolivei",
+                "password": "{{ .token }}",
+                "auth": "{{ printf `raolivei:%s` .token | b64enc }}"
               }
             }
           }
   data:
-    - secretKey: username
+    - secretKey: token
       remoteRef:
-        key: secret/pi-fleet/ghcr
-        property: username
-    - secretKey: password
-      remoteRef:
-        key: secret/pi-fleet/ghcr
+        key: secret/canopy/ghcr-token
         property: token

--- a/clusters/eldertree/ollie/ollie-secrets-external.yaml
+++ b/clusters/eldertree/ollie/ollie-secrets-external.yaml
@@ -13,9 +13,9 @@ spec:
   data:
     - secretKey: elder-api-key
       remoteRef:
-        key: secret/pi-fleet/ollie
-        property: elder_api_key
+        key: secret/elder/api-key
+        property: key
     - secretKey: openrouter-api-key
       remoteRef:
-        key: secret/pi-fleet/ollie
-        property: openrouter_api_key
+        key: secret/openclaw/openrouter
+        property: api-key

--- a/clusters/eldertree/personal-website/ghcr-secret-external.yaml
+++ b/clusters/eldertree/personal-website/ghcr-secret-external.yaml
@@ -28,5 +28,5 @@ spec:
   data:
     - secretKey: token
       remoteRef:
-        key: secret/personal-website/ghcr-token
+        key: secret/canopy/ghcr-token
         property: token

--- a/clusters/eldertree/pitanga/ghcr-secret-external.yaml
+++ b/clusters/eldertree/pitanga/ghcr-secret-external.yaml
@@ -28,6 +28,6 @@ spec:
   data:
     - secretKey: token
       remoteRef:
-        key: secret/pitanga/ghcr-token
+        key: secret/canopy/ghcr-token
         property: token
 

--- a/helm/pi-hole/templates/deployment.yaml
+++ b/helm/pi-hole/templates/deployment.yaml
@@ -181,6 +181,7 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
+        {{- if .Values.exporter.enabled }}
         - name: exporter
           image: "{{ .Values.image.exporter.repository }}:{{ .Values.image.exporter.tag }}"
           imagePullPolicy: {{ .Values.image.exporter.pullPolicy }}
@@ -222,6 +223,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+        {{- end }}
       volumes:
         - name: pihole-data
           {{- if .Values.persistence.enabled }}

--- a/helm/pi-hole/templates/service.yaml
+++ b/helm/pi-hole/templates/service.yaml
@@ -62,9 +62,11 @@ spec:
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.httpsNodePort }}
       nodePort: {{ .Values.service.httpsNodePort }}
       {{- end }}
+    {{- if .Values.exporter.enabled }}
     - name: metrics
       port: {{ .Values.service.metricsPort }}
       protocol: TCP
       targetPort: {{ .Values.service.metricsPort }}
+    {{- end }}
   selector:
     {{- include "pi-hole.selectorLabels" . | nindent 4 }}

--- a/helm/pi-hole/values.yaml
+++ b/helm/pi-hole/values.yaml
@@ -17,6 +17,10 @@ image:
     tag: latest
     pullPolicy: IfNotPresent
 
+# ghcr.io/mosher-labs/pihole6-exporter has no arm64 manifest (Pi 5). Disable on Eldertree.
+exporter:
+  enabled: true
+
 service:
   type: LoadBalancer
   # NOTE: loadBalancerClass removed because kube-vip v0.8.3 ignores services with this field.


### PR DESCRIPTION
## Summary

- Fix **external-dns** RFC2136 crash loop by updating stale Pi-hole ClusterIP (`10.43.117.25` → `10.43.153.12`).
- Disable **Pi-hole metrics exporter** on Eldertree (`exporter.enabled: false`) — `ghcr.io/mosher-labs/pihole6-exporter` has no arm64 manifest; pod stayed 2/3 Ready with empty Service endpoints, blocking BIND on port 5353.
- Align **ExternalSecret** Vault paths for `ollie`, `personal-website`, and `pitanga` with secrets that already exist (`secret/canopy/ghcr-token`, `secret/elder/api-key`, `secret/openclaw/openrouter`) instead of missing `secret/pi-fleet/*` and per-app GHCR paths.

## Test plan

- [ ] Merge and reconcile Flux: `flux reconcile source git flux-system -n flux-system && flux reconcile kustomization flux-system -n flux-system --timeout=5m`
- [ ] `kubectl get externalsecret -n ollie,personal-website,pitanga` → `SecretSynced` / `Ready=True`
- [ ] `kubectl get pods -n pi-hole` → `2/2 Running` (no exporter container)
- [ ] `kubectl get endpoints -n pi-hole pi-hole` → endpoints populated on port 5353
- [ ] `kubectl get pods -n external-dns` → RFC2136 `external-dns` pod `Running` (not CrashLoopBackOff)
- [ ] Control Center incident feed clears ExternalSecret warnings for ollie / personal-website / pitanga


Made with [Cursor](https://cursor.com)