### PR TITLE
fix: pi-hole HelmRelease loadBalancerClass for kube-vip upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **Pi-hole Helm upgrade stalled (`loadBalancerClass`)** — HelmRelease used `loadBalancerClass: null` but live Service has immutable `kube-vip.io/kube-vip-class`; align values so exporter disable can roll out.
 - **Pi-hole exporter ImagePullBackOff (arm64)** — `ghcr.io/mosher-labs/pihole6-exporter` has no arm64 manifest; pod stayed 2/3 Ready with **empty Service endpoints**, breaking RFC2136 external-dns. Chart adds `exporter.enabled` (off on Eldertree until arm64 image exists).
 - **external-dns RFC2136 crash loop** — `EXTERNAL_DNS_RFC2136_HOST` pointed at stale Pi-hole ClusterIP `10.43.117.25`; updated to current `10.43.153.12` (`kubectl get svc -n pi-hole pi-hole`).
 - **ExternalSecret Vault path drift** — `ollie`, `personal-website`, and `pitanga` `ghcr-secret` now read `secret/canopy/ghcr-token` (same as swimto/canopy). `ollie-secrets` reads `secret/elder/api-key` and `secret/openclaw/openrouter` instead of missing `secret/pi-fleet/*` paths.

--- a/clusters/eldertree/dns-services/pi-hole/helmrelease.yaml
+++ b/clusters/eldertree/dns-services/pi-hole/helmrelease.yaml
@@ -32,7 +32,8 @@ spec:
     strategy: Recreate
     service:
       type: LoadBalancer
-      loadBalancerClass: null
+      # Must match live Service (immutable once set). Do not use null — Helm patch fails.
+      loadBalancerClass: kube-vip.io/kube-vip-class
       loadBalancerIP: 192.168.2.201
     config:
       clusterIP: 192.168.2.201


### PR DESCRIPTION
## Summary

Follow-up to #230: Pi-hole Helm upgrades were **stalled** because `loadBalancerClass: null` cannot patch a Service that already has immutable `kube-vip.io/kube-vip-class`. Align the HelmRelease value so `exporter.enabled: false` can actually roll out.

## Test plan

- [ ] `flux reconcile helmrelease pi-hole -n pi-hole` succeeds (no Service patch error)
- [ ] `kubectl get pods -n pi-hole` → `2/2 Running` (no exporter)
- [ ] `kubectl get endpoints -n pi-hole pi-hole` populated
- [ ] RFC2136 `external-dns` pod `Running`


Made with [Cursor](https://cursor.com)