### PR TITLE
feat(swimto): weekly discover-facilities CronJob

### DIFF
--- a/clusters/eldertree/swimto/cronjob-discover.yaml
+++ b/clusters/eldertree/swimto/cronjob-discover.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: swimto-discover-facilities
+  namespace: swimto
+spec:
+  # Run weekly on Mondays at 6 AM Toronto time (11:00 UTC).
+  # Toronto is UTC-5 in winter / UTC-4 in summer; cluster CronJobs run
+  # in UTC so the wall-clock drifts by one hour across DST. Acceptable
+  # for a discovery report — the daily refresh has the same property.
+  schedule: "0 11 * * 1"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: swimto-discover-facilities
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: discover
+              image: ghcr.io/raolivei/swimto-api:v0.9.0 # {"$imagepolicy": "swimto:swimto-api-policy"}
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  REPORT=/tmp/discovery_report.json
+                  python /data-pipeline/jobs/discover_swim_facilities.py \
+                    --pool-type all \
+                    --out "$REPORT"
+                  python - <<'PY'
+                  import json, os
+                  from loguru import logger
+                  from sqlalchemy import create_engine, text
+
+                  with open("/tmp/discovery_report.json") as f:
+                      report = json.load(f)
+
+                  swim_active = [
+                      loc for loc in report.get("locations", [])
+                      if loc.get("schedule_source") != "no_programs"
+                  ]
+
+                  engine = create_engine(os.environ["DATABASE_URL"])
+                  with engine.connect() as conn:
+                      rows = conn.execute(
+                          text("SELECT toronto_location_id FROM facilities WHERE toronto_location_id IS NOT NULL")
+                      ).fetchall()
+                      known = {str(r[0]) for r in rows}
+
+                  unknown = [
+                      loc for loc in swim_active
+                      if str(loc.get("location_id")) not in known
+                  ]
+
+                  if unknown:
+                      logger.warning(
+                          f"Found {len(unknown)} swim-active location(s) NOT in DB: "
+                          + ", ".join(
+                              f"{loc.get('location_id')} ({loc.get('name') or 'unknown'})"
+                              for loc in unknown
+                          )
+                      )
+                  else:
+                      logger.info(
+                          f"All {len(swim_active)} swim-active location(s) already known in DB."
+                      )
+                  PY
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: swimto-secrets
+                      key: DATABASE_URL
+              envFrom:
+                - configMapRef:
+                    name: swimto-config
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+          imagePullSecrets:
+            - name: ghcr-secret

--- a/clusters/eldertree/swimto/kustomization.yaml
+++ b/clusters/eldertree/swimto/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   # CronJobs (different pattern from Deployments)
   - cronjob-refresh.yaml
   - facility-url-validator-cronjob.yaml
+  - cronjob-discover.yaml
   # Image automation (stays separate - FluxCD requirement)
   - image-repositories.yaml
   - image-policies.yaml


### PR DESCRIPTION
## What

Wires the new ``swimto-discover-facilities`` CronJob into the GitOps source of truth so FluxCD applies it on the cluster. Pairs with the swimTO repo PR raolivei/swimTO#223 (in-repo reference manifest).

- **Schedule:** Mondays 11:00 UTC (≈ 06:00 America/Toronto, drifts ±1h across DST — same trade-off as the daily refresh).
- **Image:** ``ghcr.io/raolivei/swimto-api:v0.9.0 # {"\$imagepolicy": "swimto:swimto-api-policy"}`` — Flux auto-promotes future versions.
- **Pod-spec:** ``imagePullSecrets: ghcr-secret`` (matches cronjob-refresh.yaml).
- **Workload:** runs ``data-pipeline/jobs/discover_swim_facilities.py``, then a small inline Python step diffs the report's swim-active locations against ``facilities.toronto_location_id`` and emits ``logger.warning`` if any new pools have appeared upstream — early-warning signal when the City adds locations.

## Files

- ``clusters/eldertree/swimto/cronjob-discover.yaml`` — new
- ``clusters/eldertree/swimto/kustomization.yaml`` — adds the new resource entry

## Test plan

- [ ] After merge: ``flux reconcile kustomization flux-system`` (or wait for the next interval).
- [ ] ``kubectl -n swimto get cronjobs`` — should list ``swimto-discover-facilities`` alongside the existing two.
- [ ] First Monday after merge: ``kubectl -n swimto get jobs | grep discover`` shows a successful run; ``kubectl -n swimto logs job/swimto-discover-facilities-XXXX`` ends with either "All N swim-active location(s) already known in DB." or a warning listing drift.

Closes raolivei/swimTO#183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)