### PR TITLE
feat(bolao): ARC runner and exclude public hostname from External-DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 - **bolao Cloudflare** — Tunnel ingress + CNAME `bolao.eldertree.xyz`; origin TLS ExternalSecret; public ingress excludes External-DNS (same pattern as canopy/swimTO).
 
+- **bolao ARC runner** — `gha-runner-scale-set` for `raolivei/bolao` (`bolao-eldertree`).
+
 - **bolao Flux wiring** — Register `clusters/eldertree/bolao` in root kustomization; routing registry, postgres-exporter, monitoring-stack 0.2.17 dashboard folder.
 
 - **BIND9 LAN DNS (`helm/bind9`)** — Replaces Pi-hole (#232): authoritative `eldertree.local` on VIP `192.168.2.201`, RFC2136 on port 53. external-dns host `bind9.bind.svc.cluster.local`.
@@ -20,6 +22,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 - **Ollie Helm chart** — Vendor `helm/ollie` from the [ollie](https://github.com/raolivei/ollie) repo so Flux `HelmRelease` path `./helm/ollie` resolves (fixes `InvalidChartReference`).
 
 ### Fixed
+
+- **bolao public DNS** — Exclude `bolao.eldertree.xyz` from External-DNS on public ingress so Terraform owns the Cloudflare tunnel CNAME (canopy pattern).
 
 - **Pi-hole Helm upgrade stalled (`loadBalancerClass`)** — HelmRelease used `loadBalancerClass: null` but live Service has immutable `kube-vip.io/kube-vip-class`; align values so exporter disable can roll out.
 - **Pi-hole exporter ImagePullBackOff (arm64)** — `ghcr.io/mosher-labs/pihole6-exporter` has no arm64 manifest; pod stayed 2/3 Ready with **empty Service endpoints**, breaking RFC2136 external-dns. Chart adds `exporter.enabled` (off on Eldertree until arm64 image exists).

--- a/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
@@ -1,0 +1,82 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bolao-runners
+  namespace: arc-runners
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: "0.14.2"
+      sourceRef:
+        kind: HelmRepository
+        name: arc-charts
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: arc-runners
+  releaseName: bolao-runners
+  install:
+    createNamespace: true
+  upgrade:
+    cleanupOnFail: true
+  dependsOn:
+    - name: arc-controller
+      namespace: arc-controller
+  values:
+    githubConfigUrl: "https://github.com/raolivei/bolao"
+    githubConfigSecret: ollie-runner-github-secret
+
+    minRunners: 0
+    maxRunners: 2
+
+    runnerScaleSetName: "bolao-eldertree"
+
+    scaleSetLabels:
+      - self-hosted
+
+    containerMode:
+      type: "dind"
+
+    template:
+      metadata:
+        labels:
+          workload-type: ci-cd
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: actions.github.com/scale-set-name
+                        operator: In
+                        values:
+                          - bolao-eldertree
+                  topologyKey: kubernetes.io/hostname
+        terminationGracePeriodSeconds: 3600
+
+        containers:
+          - name: runner
+            image: ghcr.io/actions/actions-runner:latest
+            command: ["/home/runner/run.sh"]
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1500m
+                memory: 2Gi
+          - name: dind
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1536Mi
+
+    controllerServiceAccount:
+      namespace: arc-controller
+      name: arc-controller-gha-rs-controller

--- a/clusters/eldertree/arc-runners/kustomization.yaml
+++ b/clusters/eldertree/arc-runners/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - northwaysignal-website-runners-helmrelease.yaml
   - nima-runners-helmrelease.yaml
   - eldertree-docs-runners-helmrelease.yaml
+  - bolao-runners-helmrelease.yaml

--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -95,4 +95,4 @@ spec:
         tls:
           secretName: bolao-cloudflare-origin-tls
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: bolao.eldertree.xyz
+          external-dns.alpha.kubernetes.io/exclude: "true"


### PR DESCRIPTION
## Summary
- Add `bolao-eldertree` ARC runner scale set for `raolivei/bolao` CI builds
- Exclude `bolao.eldertree.xyz` from External-DNS on public ingress (canopy pattern) so Terraform tunnel CNAME can apply

## Test plan
- [ ] Terraform CI passes
- [ ] Flux reconciles `bolao-runners` AutoscalingRunnerSet
- [ ] `bolao.eldertree.xyz` DNS managed by Terraform tunnel CNAME


Made with [Cursor](https://cursor.com)