### PR TITLE
fix(terraform): reconcile bolao.eldertree.xyz DNS before apply

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -181,6 +181,16 @@ jobs:
         working-directory: .
         run: bash scripts/cloudflare-reconcile-control-dns.sh
 
+      - name: Reconcile bolao.eldertree.xyz DNS (tunnel CNAME)
+        if: |
+          steps.plan.outcome == 'success' &&
+          (
+            (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.apply == 'true')
+          )
+        working-directory: .
+        run: bash scripts/cloudflare-reconcile-bolao-dns.sh
+
       - name: Terraform Apply
         id: apply
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **bolao.eldertree.xyz Terraform DNS** — `cloudflare-reconcile-bolao-dns.sh` deletes stale External-DNS A records before apply (same pattern as `control.eldertree.xyz`)
+
 - **bolao public DNS** — Exclude `bolao.eldertree.xyz` from External-DNS on public ingress so Terraform owns the Cloudflare tunnel CNAME (canopy pattern).
 
 - **Pi-hole Helm upgrade stalled (`loadBalancerClass`)** — HelmRelease used `loadBalancerClass: null` but live Service has immutable `kube-vip.io/kube-vip-class`; align values so exporter disable can roll out.

--- a/scripts/cloudflare-reconcile-bolao-dns.sh
+++ b/scripts/cloudflare-reconcile-bolao-dns.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Remove stale Cloudflare DNS records for bolao.eldertree.xyz so Terraform can
+# create the tunnel CNAME (cloudflare_record.bolao_eldertree_xyz_tunnel).
+#
+# Fails when external-dns or manual A records exist with the same name but
+# different type/target than the tunnel CNAME.
+#
+# Usage (secrets from Vault via run-terraform.sh env):
+#   source scripts/lib/load-terraform-secrets-from-vault.sh
+#   export TF_VAR_cloudflare_api_token TF_VAR_cloudflare_zone_id
+#   ./scripts/cloudflare-reconcile-bolao-dns.sh
+#
+# CI: run before terraform apply when bolao CNAME fails with allow_overwrite mismatch.
+
+set -euo pipefail
+
+TOKEN="${TF_VAR_cloudflare_api_token:-${CLOUDFLARE_API_TOKEN:-}}"
+ZONE_ID="${TF_VAR_cloudflare_zone_id:-${CLOUDFLARE_ZONE_ID:-}}"
+NAME="bolao"
+
+if [[ -z "$TOKEN" || -z "$ZONE_ID" ]]; then
+  echo "Need TF_VAR_cloudflare_api_token and TF_VAR_cloudflare_zone_id" >&2
+  exit 1
+fi
+
+api() {
+  curl -sfS -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "$@"
+}
+
+echo "Listing Cloudflare records for ${NAME}.eldertree.xyz (zone ${ZONE_ID})..."
+RECORDS="$(api "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${NAME}.eldertree.xyz")"
+echo "$RECORDS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if not data.get('success'):
+    print('API error:', data, file=sys.stderr)
+    sys.exit(1)
+for r in data.get('result', []):
+    print(f\"{r['id']}\t{r['type']}\t{r.get('content','')}\")
+"
+
+while IFS=$'\t' read -r id rtype content; do
+  [[ -z "$id" ]] && continue
+  if [[ "$rtype" == "CNAME" && "$content" == *".cfargotunnel.com" ]]; then
+    echo "OK: tunnel CNAME already present ($id)"
+    continue
+  fi
+  echo "Deleting ${rtype} record $id (${content})..."
+  api -X DELETE "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${id}" >/dev/null
+  echo "Deleted."
+done < <(echo "$RECORDS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for r in data.get('result', []):
+    print(r['id'], r['type'], r.get('content',''), sep='\t')
+")
+
+echo "Done. Re-run: cd terraform && terraform apply"


### PR DESCRIPTION
## Summary
Fixes [Terraform run #27923336509](https://github.com/raolivei/pi-fleet/actions/runs/27923336509) failure:
\`cloudflare_record.bolao_eldertree_xyz_tunnel\` — "attempted to override existing record however didn't find an exact match"

- Add `scripts/cloudflare-reconcile-bolao-dns.sh` (same pattern as control DNS reconcile)
- Run before `terraform apply` in CI to delete stale External-DNS A records

## Test plan
- [ ] Terraform CI plan passes on PR
- [ ] Terraform apply on main creates `bolao.eldertree.xyz` tunnel CNAME
- [ ] `curl -fsSI https://bolao.eldertree.xyz/` returns 200


Made with [Cursor](https://cursor.com)