### PR TITLE
fix(bolao): pod DNS fallback and AUTH_TRUST_HOST for Google OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
+- **bolao OAuth DNS** — `bolao-web` pod `dnsConfig` (CoreDNS + 8.8.8.8 fallback) and `AUTH_TRUST_HOST=true` for Auth.js behind Cloudflare
+- **eldertree-app chart** — optional `dnsConfig` on component deployments
+
 - **bolao.eldertree.xyz Terraform DNS** — `cloudflare-reconcile-bolao-dns.sh` deletes stale External-DNS A records before apply (same pattern as `control.eldertree.xyz`)
 
 - **bolao public DNS** — Exclude `bolao.eldertree.xyz` from External-DNS on public ingress so Terraform owns the Cloudflare tunnel CNAME (canopy pattern).

--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
       bolao-web:
         image:
           repository: ghcr.io/raolivei/bolao-web
-          tag: v0.1.0
+          tag: v0.1.1
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000
@@ -65,6 +65,15 @@ spec:
               secretKeyRef:
                 name: bolao-secrets
                 key: CRON_SECRET
+          - name: AUTH_TRUST_HOST
+            value: "true"
+        dnsConfig:
+          nameservers:
+            - 10.43.0.10
+            - 8.8.8.8
+          options:
+            - name: ndots
+              value: "2"
         resources:
           requests: { cpu: "100m", memory: "256Mi" }
           limits: { cpu: "500m", memory: "512Mi" }

--- a/helm/eldertree-app/templates/deployment.yaml
+++ b/helm/eldertree-app/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $component.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $component.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes Google OAuth DNS resolution in cluster. Bump image tag to v0.1.1.

Made with [Cursor](https://cursor.com)