### PR TITLE
feat(bolao): add Flux image automation and ARC stress coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
-- **bolao Cloudflare** — Tunnel ingress + CNAME `bolao.eldertree.xyz`; origin TLS ExternalSecret; public ingress excludes External-DNS (same pattern as canopy/swimTO).
+- **bolao Flux image automation** — `ImageRepository`, `ImagePolicy`, and `ImageUpdateAutomation` for `ghcr.io/raolivei/bolao-web`; HelmRelease tag setter comment (swimTO pattern).
+
+### Changed
+
+- **`stress-arc-runners.sh`** — include `bolao` in default `ARC_REPOS` (repo-scoped scale set deployed).
+
+### Added
 
 - **bolao ARC runner** — `gha-runner-scale-set` for `raolivei/bolao` (`bolao-eldertree`).
 

--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
       bolao-web:
         image:
           repository: ghcr.io/raolivei/bolao-web
-          tag: v0.1.1
+          tag: v0.1.1 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000

--- a/clusters/eldertree/bolao/image-policies.yaml
+++ b/clusters/eldertree/bolao/image-policies.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: bolao-web-policy
+  namespace: bolao
+spec:
+  imageRepositoryRef:
+    name: bolao-web
+  policy:
+    semver:
+      range: '>=0.1.0 <1.0.0'

--- a/clusters/eldertree/bolao/image-repositories.yaml
+++ b/clusters/eldertree/bolao/image-repositories.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: bolao-web
+  namespace: bolao
+spec:
+  image: ghcr.io/raolivei/bolao-web
+  interval: 30m
+  secretRef:
+    name: ghcr-secret

--- a/clusters/eldertree/bolao/image-update-automation.yaml
+++ b/clusters/eldertree/bolao/image-update-automation.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: bolao-updates
+  namespace: bolao
+spec:
+  interval: 30m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: "chore(bolao): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
+    push:
+      branch: main
+  update:
+    path: ./clusters/eldertree/bolao
+    strategy: Setters

--- a/clusters/eldertree/bolao/kustomization.yaml
+++ b/clusters/eldertree/bolao/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - postgres-pvc.yaml
   - postgres-deployment.yaml
   - helmrelease.yaml
+  # Image automation (stays separate - FluxCD requirement)
+  - image-repositories.yaml
+  - image-policies.yaml
+  - image-update-automation.yaml
   - cronjob-results-sync.yaml
   - cronjob-standings-sync.yaml
   - cronjob-leaderboard-sync.yaml

--- a/scripts/stress-arc-runners.sh
+++ b/scripts/stress-arc-runners.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Repos with deployed scale sets — update as phases roll out
-ARC_REPOS="${ARC_REPOS:-ollie pi-fleet-blog elder github-workflows canopy swimTO personal-website northwaysignal-website nima eldertree-docs}"
+ARC_REPOS="${ARC_REPOS:-ollie pi-fleet-blog elder github-workflows canopy swimTO bolao personal-website northwaysignal-website nima eldertree-docs}"
 
 has_repo() {
   local want=$1


### PR DESCRIPTION
## Summary
- Add Flux `ImageRepository`, `ImagePolicy`, and `ImageUpdateAutomation` for `ghcr.io/raolivei/bolao-web` (swimTO pattern).
- Wire resources in `kustomization.yaml` and HelmRelease image tag setter comment.
- Include `bolao` in default `ARC_REPOS` for `stress-arc-runners.sh`.
- Update `CHANGELOG.md`.

## Test plan
- [ ] `kubectl kustomize clusters/eldertree/bolao` (or Flux build) validates manifests.
- [ ] After merge, confirm Flux reconciles image automation CRs in `bolao` namespace.
- [ ] After bolao CI PR merges and pushes a new tag, verify ImagePolicy picks up tag and HelmRelease updates.
- [ ] Optional: run `scripts/stress-arc-runners.sh` with defaults and confirm bolao scale set is exercised.

Made with [Cursor](https://cursor.com)