### PR TITLE
fix(arc): dnsConfig on bolao DinD runners for npm registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
-- **bolao OAuth DNS** — `bolao-web` pod `dnsConfig` (CoreDNS + 8.8.8.8 fallback) and `AUTH_TRUST_HOST=true` for Auth.js behind Cloudflare
+- **bolao ARC runner DNS** — `dnsConfig` (CoreDNS + 8.8.8.8 fallback) on `bolao-eldertree` DinD pods so Docker build steps can resolve `registry.npmjs.org`
 - **eldertree-app chart** — optional `dnsConfig` on component deployments
 
 - **bolao.eldertree.xyz Terraform DNS** — `cloudflare-reconcile-bolao-dns.sh` deletes stale External-DNS A records before apply (same pattern as `control.eldertree.xyz`)

--- a/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
@@ -43,6 +43,15 @@ spec:
         labels:
           workload-type: ci-cd
       spec:
+        # DinD build containers inherit pod DNS; CoreDNS + 8.8.8.8 fallback
+        # fixes registry.npmjs.org EAI_AGAIN during docker build (bolao-web #243).
+        dnsConfig:
+          nameservers:
+            - 10.43.0.10
+            - 8.8.8.8
+          options:
+            - name: ndots
+              value: "2"
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/docs/ARC_RUNNERS.md
+++ b/docs/ARC_RUNNERS.md
@@ -170,6 +170,8 @@ Each repo gets a HelmRelease with `githubConfigUrl: https://github.com/raolivei/
 
    **Resource sizing (Pi 5 cluster):** Each runner pod is runner + DinD (~100m+512Mi requests). No `node-tier: stable` nodeSelector — node-1 absorbs overflow when node-2/3 are full. Cluster-wide budget: **4–6 concurrent DinD runners** under normal load; avoid firing all scale sets at once (stress script).
 
+**DinD + npm/pnpm builds:** If Docker build fails with `getaddrinfo EAI_AGAIN registry.npmjs.org`, add pod `dnsConfig` with CoreDNS (`10.43.0.10`) plus `8.8.8.8` fallback on the scale set `template.spec` (same pattern as `bolao-web` in `clusters/eldertree/bolao/helmrelease.yaml`). DinD build containers inherit the runner pod's resolvers.
+
 3. Update `clusters/eldertree/arc-runners/kustomization.yaml`
 4. Commit and push — Flux deploys automatically
 


### PR DESCRIPTION
## Summary
- Add pod `dnsConfig` (CoreDNS `10.43.0.10` + `8.8.8.8` fallback) to `bolao-eldertree` ARC runner scale set
- DinD Docker build containers inherit runner pod DNS; fixes `getaddrinfo EAI_AGAIN registry.npmjs.org` during bolao PR #55 self-hosted builds
- Document DinD + npm DNS pattern in `docs/ARC_RUNNERS.md`

## Test plan
- [ ] Flux reconciles `bolao-runners` HelmRelease
- [ ] Re-run bolao PR #55 `build-and-push` workflow on ARC runner
- [ ] `docker build` completes `pnpm install` without EAI_AGAIN


Made with [Cursor](https://cursor.com)