### PR TITLE
fix(arc): DinD daemon.json DNS for bolao npm builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Fixed
 
-- **bolao ARC runner DNS** — `dnsConfig` (CoreDNS + 8.8.8.8 fallback) on `bolao-eldertree` DinD pods so Docker build steps can resolve `registry.npmjs.org`
+- **bolao ARC runner DNS** — pod `dnsConfig` plus DinD `daemon.json` DNS on `bolao-eldertree` so buildx containers resolve `registry.npmjs.org`
 - **eldertree-app chart** — optional `dnsConfig` on component deployments
 
 - **bolao.eldertree.xyz Terraform DNS** — `cloudflare-reconcile-bolao-dns.sh` deletes stale External-DNS A records before apply (same pattern as `control.eldertree.xyz`)

--- a/clusters/eldertree/arc-runners/bolao-dind-daemon-configmap.yaml
+++ b/clusters/eldertree/arc-runners/bolao-dind-daemon-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bolao-dind-daemon
+  namespace: arc-runners
+data:
+  daemon.json: |
+    {
+      "dns": ["10.43.0.10", "8.8.8.8", "1.1.1.1"]
+    }

--- a/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
@@ -66,6 +66,11 @@ spec:
                   topologyKey: kubernetes.io/hostname
         terminationGracePeriodSeconds: 3600
 
+        volumes:
+          - name: dind-daemon-config
+            configMap:
+              name: bolao-dind-daemon
+
         containers:
           - name: runner
             image: ghcr.io/actions/actions-runner:latest
@@ -78,6 +83,11 @@ spec:
                 cpu: 1500m
                 memory: 2Gi
           - name: dind
+            volumeMounts:
+              - name: dind-daemon-config
+                mountPath: /etc/docker/daemon.json
+                subPath: daemon.json
+                readOnly: true
             resources:
               requests:
                 cpu: 50m

--- a/clusters/eldertree/arc-runners/kustomization.yaml
+++ b/clusters/eldertree/arc-runners/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - nima-runners-helmrelease.yaml
   - eldertree-docs-runners-helmrelease.yaml
   - bolao-runners-helmrelease.yaml
+  - bolao-dind-daemon-configmap.yaml

--- a/docs/ARC_RUNNERS.md
+++ b/docs/ARC_RUNNERS.md
@@ -170,7 +170,7 @@ Each repo gets a HelmRelease with `githubConfigUrl: https://github.com/raolivei/
 
    **Resource sizing (Pi 5 cluster):** Each runner pod is runner + DinD (~100m+512Mi requests). No `node-tier: stable` nodeSelector — node-1 absorbs overflow when node-2/3 are full. Cluster-wide budget: **4–6 concurrent DinD runners** under normal load; avoid firing all scale sets at once (stress script).
 
-**DinD + npm/pnpm builds:** If Docker build fails with `getaddrinfo EAI_AGAIN registry.npmjs.org`, add pod `dnsConfig` with CoreDNS (`10.43.0.10`) plus `8.8.8.8` fallback on the scale set `template.spec` (same pattern as `bolao-web` in `clusters/eldertree/bolao/helmrelease.yaml`). DinD build containers inherit the runner pod's resolvers.
+**DinD + npm/pnpm builds:** If Docker build fails with `getaddrinfo EAI_AGAIN registry.npmjs.org`, configure **both** (1) pod `dnsConfig` with CoreDNS (`10.43.0.10`) plus `8.8.8.8` fallback on `template.spec`, and (2) mount a `daemon.json` on the **dind** sidecar with the same DNS servers — buildx containers use the Docker daemon resolver, not the pod's `resolv.conf`. See `bolao-dind-daemon-configmap.yaml` + `bolao-runners-helmrelease.yaml`.
 
 3. Update `clusters/eldertree/arc-runners/kustomization.yaml`
 4. Commit and push — Flux deploys automatically


### PR DESCRIPTION
## Summary
- Pod `dnsConfig` alone did not fix `registry.npmjs.org` EAI_AGAIN inside buildx containers
- Mount `daemon.json` with CoreDNS + 8.8.8.8/1.1.1.1 on the bolao dind sidecar
- ConfigMap: `bolao-dind-daemon-configmap.yaml`

## Test plan
- [ ] Flux reconciles bolao-runners
- [ ] Re-run bolao PR #55 build-and-push on ARC


Made with [Cursor](https://cursor.com)