### PR TITLE
fix: bolao-web HelmRelease image v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **bolao-web image** — HelmRelease `bolao-web` tag `v0.1.2` (Google OAuth issuer fix; cluster may run sideload until GHCR publishes).
+
 - **`stress-arc-runners.sh`** — include `bolao` in default `ARC_REPOS` (repo-scoped scale set deployed).
 
 ### Added

--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
       bolao-web:
         image:
           repository: ghcr.io/raolivei/bolao-web
-          tag: v0.1.1 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
+          tag: v0.1.2 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000


### PR DESCRIPTION
## Summary
- Bump `clusters/eldertree/bolao/helmrelease.yaml` `bolao-web` image tag from `v0.1.1` to `v0.1.2` (ImagePolicy setter comment preserved).
- Cluster already runs `ghcr.io/raolivei/bolao-web:v0.1.2` (sideload/hotfix until GHCR publish catches up).

## Test plan
- [ ] GitGuardian / CI green
- [ ] After merge: `flux reconcile` or wait for interval; confirm HelmRelease values match deployment image


Made with [Cursor](https://cursor.com)