### PR TITLE
fix: bolao-web imagePullPolicy Always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **bolao-web `pullPolicy`** — Set `pullPolicy: Always` on `bolao-web` so Flux semver tag updates re-resolve GHCR digests (canopy pattern; alternative is pinning `image.tag` to digest).
+
 - **bolao-web image** — HelmRelease `bolao-web` tag `v0.1.2` (Google OAuth issuer fix; cluster may run sideload until GHCR publishes).
 
 - **`stress-arc-runners.sh`** — include `bolao` in default `ARC_REPOS` (repo-scoped scale set deployed).

--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -21,10 +21,11 @@ spec:
   values:
     components:
       bolao-web:
+        # Semver tag from ImagePolicy can point at a new GHCR digest; Always re-pull on pod start.
         image:
           repository: ghcr.io/raolivei/bolao-web
           tag: v0.1.2 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
-          pullPolicy: IfNotPresent
+          pullPolicy: Always
         replicas: 1
         port: 3000
         probesEnabled: false


### PR DESCRIPTION
## Summary
- Set `components.bolao-web.image.pullPolicy: Always` in bolao `HelmRelease` so pods re-pull when the semver tag is unchanged but GHCR digest updates (Flux ImagePolicy pattern).
- Documented in CHANGELOG; alternative is pinning `image.tag` to digest instead of semver.

## Context
- **eldertree-app** maps `image.pullPolicy` → Deployment `imagePullPolicy` (`helm/eldertree-app/templates/deployment.yaml`).
- **canopy** uses `pullPolicy: Always` with `latest` (comment in helmrelease).
- **swimTO** still uses `pullPolicy: IfNotPresent` with Flux semver tags (`v0.9.2`).

## Test plan
- [ ] Flux reconciles bolao HelmRelease without drift on pullPolicy
- [ ] After rollout/restart, `kubectl get deploy bolao-web -n bolao -o jsonpath='{.spec.template.spec.containers[0].imagePullPolicy}'` → `Always`


Made with [Cursor](https://cursor.com)