### PR TITLE
feat(bolao-claude): add namespace + helmrelease + flux automation

### DIFF
--- a/clusters/eldertree/bolao-claude/bolao-claude-secrets-external.yaml
+++ b/clusters/eldertree/bolao-claude/bolao-claude-secrets-external.yaml
@@ -1,0 +1,49 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: bolao-claude-secrets
+  namespace: bolao-claude
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: bolao-claude-secrets
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        DATABASE_URL: "postgresql://postgres:{{ .postgresPassword }}@postgres-service:5432/bolao"
+        AUTH_SECRET: "{{ .authSecret }}"
+        AUTH_URL: "https://bolao-claude.eldertree.xyz"
+        GOOGLE_CLIENT_ID: "{{ .googleClientId }}"
+        GOOGLE_CLIENT_SECRET: "{{ .googleClientSecret }}"
+        FOOTBALL_DATA_API_KEY: "{{ .footballDataApiKey | default \"\" }}"
+        CRON_SECRET: "{{ .cronSecret }}"
+        postgres-password: "{{ .postgresPassword }}"
+  data:
+    - secretKey: postgresPassword
+      remoteRef:
+        key: secret/bolao-claude/postgres
+        property: password
+    - secretKey: authSecret
+      remoteRef:
+        key: secret/bolao-claude/app
+        property: auth-secret
+    - secretKey: googleClientId
+      remoteRef:
+        key: secret/bolao-claude/app
+        property: google-client-id
+    - secretKey: googleClientSecret
+      remoteRef:
+        key: secret/bolao-claude/app
+        property: google-client-secret
+    - secretKey: footballDataApiKey
+      remoteRef:
+        key: secret/bolao-claude/app
+        property: football-data-api-key
+    - secretKey: cronSecret
+      remoteRef:
+        key: secret/bolao-claude/app
+        property: cron-secret

--- a/clusters/eldertree/bolao-claude/cloudflare-origin-cert-external.yaml
+++ b/clusters/eldertree/bolao-claude/cloudflare-origin-cert-external.yaml
@@ -1,0 +1,35 @@
+---
+# ExternalSecret for *.eldertree.xyz Cloudflare Origin Certificate
+# Reuses the wildcard cert stored in Vault (shared across all *.eldertree.xyz subdomains)
+# Used by bolao-claude.eldertree.xyz for public HTTPS access
+#
+# Vault path: secret/swimto/cloudflare-origin-cert-eldertree
+# (Wildcard cert covers *.eldertree.xyz and eldertree.xyz)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: bolao-claude-cloudflare-origin-cert
+  namespace: bolao-claude
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: bolao-claude-cloudflare-origin-tls
+    # Merge updates existing secret (e.g. if created manually); avoids "secret already exists" error
+    creationPolicy: Merge
+    template:
+      type: kubernetes.io/tls
+      data:
+        tls.crt: "{{ .certificate }}"
+        tls.key: "{{ .privatekey }}"
+  data:
+    - secretKey: certificate
+      remoteRef:
+        key: secret/swimto/cloudflare-origin-cert-eldertree
+        property: certificate
+    - secretKey: privatekey
+      remoteRef:
+        key: secret/swimto/cloudflare-origin-cert-eldertree
+        property: private-key

--- a/clusters/eldertree/bolao-claude/cronjob-alceu-feed-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-alceu-feed-sync.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bolao-claude-alceu-feed-sync
+  namespace: bolao-claude
+spec:
+  schedule: "*/20 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: curlimages/curl:8.11.1
+              command: ["/bin/sh", "-c"]
+              args:
+                - 'curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" http://bolao-claude-web:3000/api/internal/cron/alceu-feed-sync'
+              env:
+                - name: CRON_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: bolao-claude-secrets
+                      key: CRON_SECRET

--- a/clusters/eldertree/bolao-claude/cronjob-leaderboard-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-leaderboard-sync.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bolao-claude-leaderboard-sync
+  namespace: bolao-claude
+spec:
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: curlimages/curl:8.11.1
+              command: ["/bin/sh", "-c"]
+              args:
+                - 'curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" http://bolao-claude-web:3000/api/internal/cron/leaderboard-sync'
+              env:
+                - name: CRON_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: bolao-claude-secrets
+                      key: CRON_SECRET

--- a/clusters/eldertree/bolao-claude/cronjob-results-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-results-sync.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bolao-claude-results-sync
+  namespace: bolao-claude
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: curlimages/curl:8.11.1
+              command: ["/bin/sh", "-c"]
+              args:
+                - 'curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" http://bolao-claude-web:3000/api/internal/cron/results-sync'
+              env:
+                - name: CRON_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: bolao-claude-secrets
+                      key: CRON_SECRET

--- a/clusters/eldertree/bolao-claude/cronjob-standings-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-standings-sync.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bolao-claude-standings-sync
+  namespace: bolao-claude
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: curlimages/curl:8.11.1
+              command: ["/bin/sh", "-c"]
+              args:
+                - 'curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" http://bolao-claude-web:3000/api/internal/cron/standings-sync'
+              env:
+                - name: CRON_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: bolao-claude-secrets
+                      key: CRON_SECRET

--- a/clusters/eldertree/bolao-claude/ghcr-secret-external.yaml
+++ b/clusters/eldertree/bolao-claude/ghcr-secret-external.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-secret
+  namespace: bolao-claude
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      engineVersion: v2
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "raolivei",
+                "password": "{{ .token }}",
+                "auth": "{{ printf "raolivei:%s" .token | b64enc }}"
+              }
+            }
+          }
+  data:
+    - secretKey: token
+      remoteRef:
+        key: secret/canopy/ghcr-token
+        property: token

--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -1,0 +1,95 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bolao-claude
+  namespace: bolao-claude
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: ./helm/eldertree-app
+      version: "0.1.2"
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: bolao-claude
+  releaseName: bolao-claude
+  upgrade:
+    cleanupOnFail: true
+  values:
+    components:
+      bolao-claude-web:
+        image:
+          repository: ghcr.io/raolivei/bolao-claude-web # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
+          tag: v0.1.0
+          pullPolicy: IfNotPresent
+        replicas: 1
+        port: 3000
+        probesEnabled: false
+        sessionAffinity: ClientIP
+        env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: bolao-claude-secrets
+                key: DATABASE_URL
+          - name: AUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: bolao-claude-secrets
+                key: AUTH_SECRET
+          - name: AUTH_URL
+            value: https://bolao-claude.eldertree.xyz
+          - name: GOOGLE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: bolao-claude-secrets
+                key: GOOGLE_CLIENT_ID
+          - name: GOOGLE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: bolao-claude-secrets
+                key: GOOGLE_CLIENT_SECRET
+          - name: FOOTBALL_DATA_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: bolao-claude-secrets
+                key: FOOTBALL_DATA_API_KEY
+          - name: CRON_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: bolao-claude-secrets
+                key: CRON_SECRET
+        resources:
+          requests: { cpu: "100m", memory: "256Mi" }
+          limits: { cpu: "500m", memory: "512Mi" }
+        serviceAnnotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "3000"
+          prometheus.io/path: "/api/metrics"
+    middleware:
+      redirect-https:
+        type: redirectScheme
+        scheme: https
+        permanent: true
+    ingress:
+      bolao-claude-local:
+        host: bolao-claude.eldertree.local
+        service: bolao-claude-web
+        port: 3000
+        middlewares: ["bolao-claude-redirect-https@kubernetescrd"]
+        tls:
+          secretName: bolao-claude-tls
+          certManager: true
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: bolao-claude.eldertree.local
+      bolao-claude-public:
+        host: bolao-claude.eldertree.xyz
+        service: bolao-claude-web
+        port: 3000
+        tls:
+          secretName: bolao-claude-cloudflare-origin-tls
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: bolao-claude.eldertree.xyz

--- a/clusters/eldertree/bolao-claude/image-policies.yaml
+++ b/clusters/eldertree/bolao-claude/image-policies.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: bolao-claude-web-policy
+  namespace: bolao-claude
+spec:
+  imageRepositoryRef:
+    name: bolao-claude-web
+  policy:
+    semver:
+      range: '>=0.1.0 <1.0.0'

--- a/clusters/eldertree/bolao-claude/image-repositories.yaml
+++ b/clusters/eldertree/bolao-claude/image-repositories.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: bolao-claude-web
+  namespace: bolao-claude
+spec:
+  image: ghcr.io/raolivei/bolao-claude-web
+  interval: 30m
+  secretRef:
+    name: ghcr-secret

--- a/clusters/eldertree/bolao-claude/image-update-automation.yaml
+++ b/clusters/eldertree/bolao-claude/image-update-automation.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: bolao-claude-updates
+  namespace: bolao-claude
+spec:
+  interval: 30m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: "chore(bolao-claude): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
+    push:
+      branch: main
+  update:
+    path: ./clusters/eldertree/bolao-claude
+    strategy: Setters

--- a/clusters/eldertree/bolao-claude/kustomization.yaml
+++ b/clusters/eldertree/bolao-claude/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - ghcr-secret-external.yaml
+  - bolao-claude-secrets-external.yaml
+  - cloudflare-origin-cert-external.yaml
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - helmrelease.yaml
+  - image-repositories.yaml
+  - image-policies.yaml
+  - image-update-automation.yaml
+  - cronjob-results-sync.yaml
+  - cronjob-standings-sync.yaml
+  - cronjob-leaderboard-sync.yaml
+  - cronjob-alceu-feed-sync.yaml

--- a/clusters/eldertree/bolao-claude/namespace.yaml
+++ b/clusters/eldertree/bolao-claude/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bolao-claude
+  labels:
+    name: bolao-claude
+    app: bolao-claude

--- a/clusters/eldertree/bolao-claude/postgres-deployment.yaml
+++ b/clusters/eldertree/bolao-claude/postgres-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: bolao-claude
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: bolao
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: bolao-claude-secrets
+                  key: postgres-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  namespace: bolao-claude
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/clusters/eldertree/bolao-claude/postgres-pvc.yaml
+++ b/clusters/eldertree/bolao-claude/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: bolao-claude
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi

--- a/clusters/eldertree/kustomization.yaml
+++ b/clusters/eldertree/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   # Applications
   - canopy # Personal finance dashboard
   - bolao # Bolão dos Guerreiros — WC 2026 prediction pool
+  - bolao-claude # Bolão (Claude scratch) — separate namespace; image ghcr.io/raolivei/bolao-claude-web
   - swimto # Toronto pool schedules
   - pitanga/flux-kustomization.yaml # Pitanga Cloud (managed by its own Flux Kustomization)
   - ollie # Workspace assistant with RAG and LLM


### PR DESCRIPTION
## Summary

Adds new K8s namespace `bolao-claude` for the [raolivei/bolao-claude](https://github.com/raolivei/bolao-claude) scratch repo, alongside the production `bolao` namespace. Same pattern as `swimto`/`canopy`/`ollie`: per-app namespace with its own postgres, ESO secrets, helmrelease, image automation, cronjobs.

## What ships

- **Namespace**: `bolao-claude`
- **Public URL**: `https://bolao-claude.eldertree.xyz` (Cloudflare origin TLS, *.eldertree.xyz wildcard)
- **LAN URL**: `https://bolao-claude.eldertree.local` (ca-cluster-issuer)
- **Image**: `ghcr.io/raolivei/bolao-claude-web` (Flux image automation, semver `>=0.1.0 <1.0.0`)
- **DB**: own postgres deployment in-namespace (PVC 2Gi local-path, 256Mi/512Mi)
- **Vault path**: `secret/bolao-claude/*` (already populated)

15 manifests under `clusters/eldertree/bolao-claude/`:
- namespace, postgres pvc + deployment
- ExternalSecrets: bolao-claude-secrets, cloudflare-origin-cert, ghcr-secret
- helmrelease (eldertree-app chart 0.1.2, single component bolao-claude-web)
- Flux image automation: ImageRepository + ImagePolicy + ImageUpdateAutomation
- 4 cronjobs (results-sync, standings-sync, leaderboard-sync, alceu-feed-sync)

Plus parent `clusters/eldertree/kustomization.yaml` adds `- bolao-claude` after the existing `- bolao` line.

## Vault state (pre-PR)

`secret/bolao-claude/` already populated with:
- `postgres` → `password`
- `app` → `auth-secret`, `google-client-id`, `google-client-secret`, `cron-secret`, `football-data-api-key` (empty placeholder, rotate via Vault UI when ready)

## Validation

- `kubectl kustomize clusters/eldertree/bolao-claude/` → 15 resources render clean
- `kubectl apply --dry-run=client` → clean on all manifests
- Image `ghcr.io/raolivei/bolao-claude-web:v0.1.0` published from [bolao-claude run 27927074815](https://github.com/raolivei/bolao-claude/actions/runs/27927074815)

## Test plan

- [ ] PR merges → Flux reconciles `clusters/eldertree`
- [ ] Namespace `bolao-claude` appears: `kubectl get ns bolao-claude`
- [ ] ExternalSecrets sync: `kubectl get externalsecret -n bolao-claude` (3 should be `SecretSynced=True`)
- [ ] Postgres pod Running: `kubectl get pods -n bolao-claude -l app=postgres`
- [ ] HelmRelease ready: `kubectl get helmrelease bolao-claude -n bolao-claude`
- [ ] App pod Running + serving: `kubectl get pods -n bolao-claude -l component=bolao-claude-web`
- [ ] Public URL responds: `curl -fsS https://bolao-claude.eldertree.xyz/api/metrics`

## Post-deploy

1. Add `https://bolao-claude.eldertree.xyz/api/auth/callback/google` to the Google OAuth client redirect URIs (Google Cloud Console — practical-gecko-203803, client `738498476051-29...`). Without this, login returns `redirect_uri_mismatch`.
2. Rotate `football-data-api-key` in Vault when you have a real key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)