### PR TITLE
fix(swimto): rolling update without surge to clear anti-affinity deadlock

### DIFF
--- a/clusters/eldertree/swimto/helmrelease.yaml
+++ b/clusters/eldertree/swimto/helmrelease.yaml
@@ -27,6 +27,18 @@ spec:
     components:
       swimto-api:
         replicas: 2
+        # ``maxSurge: 0`` is required because pod-anti-affinity is
+        # ``required`` on hostname topology and only 2 nodes are
+        # schedulable (node-1 is labelled ``unstable``). With surge,
+        # the rolling update would try to land a 3rd pod that has no
+        # legal home and Helm would time out at 5min — see #228.
+        # ``maxUnavailable: 1`` means we drop to a single api pod
+        # briefly during release; acceptable for swimTO's traffic.
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 0
+            maxUnavailable: 1
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/eldertree-app/templates/deployment.yaml
+++ b/helm/eldertree-app/templates/deployment.yaml
@@ -19,7 +19,11 @@ spec:
       {{- include "eldertree-app.selectorLabels" (dict "releaseName" $.Release.Name "componentName" $name) | nindent 6 }}
   {{- if $component.strategy }}
   strategy:
+    {{- if kindIs "string" $component.strategy }}
     type: {{ $component.strategy }}
+    {{- else }}
+    {{- toYaml $component.strategy | nindent 4 }}
+    {{- end }}
   {{- end }}
   template:
     metadata:


### PR DESCRIPTION
## Why

Closes raolivei/swimTO#228 — the deadlock that blocked the v0.9.1 rollout and required manual pod deletion to recover.

## The deadlock

Cluster has 3 nodes; node-1 is labelled ``eldertree.xyz/node-tier: unstable`` and the swimto-api Deployment's ``nodeAffinity`` excludes it. That leaves 2 schedulable nodes for 2 api replicas. Combined with the existing ``required`` ``podAntiAffinity`` (one swimto-api per host) and the chart's default ``maxSurge: 1``, every rolling update tries to land the new pod on a 3rd host that doesn't exist:

\`\`\`
0/3 nodes are available: 1 node(s) didn't match Pod's node affinity/selector, 2 node(s) didn't match pod anti-affinity rules.
\`\`\`

HelmRelease times out at 5min, ``Released: False, Stalled: True``. Cluster sits on the previous image until someone deletes old pods by hand.

## Fix

**Two changes:**

1. ``helm/eldertree-app/templates/deployment.yaml`` — accept either a string (legacy ``strategy: Recreate``) OR a full object for ``strategy``. ``kindIs "string"`` discriminates. Backwards-compatible with every existing chart consumer.

2. ``clusters/eldertree/swimto/helmrelease.yaml`` — set the swimto-api rolling-update strategy to ``maxSurge: 0, maxUnavailable: 1`` so releases drop to a single pod briefly instead of trying to surge to three.

## Verification

\`helm template\` against the modified chart:

| Input | Output |
|-------|--------|
| ``strategy: Recreate`` (string) | ``strategy: { type: Recreate }`` |
| ``strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 0, maxUnavailable: 1 }}`` | full RollingUpdate block, all fields preserved |

## Test plan

- [x] Merge.
- [ ] Wait for Flux to reconcile (``flux reconcile kustomization flux-system`` for impatience).
- [ ] Trigger a swimto-api rollout: ``kubectl -n swimto rollout restart deploy swimto-api``.
- [ ] Watch ``kubectl -n swimto get pods -l app=swimto-api`` — old pod terminates first (``Terminating``), new pod schedules onto the freed node, **no Pending stuck on anti-affinity**.
- [ ] Confirm ``kubectl -n swimto get helmrelease swimto`` reports ``Ready: True``.

## Trade-off

During the rolling window we have 1 api pod (instead of 2). That's a brief 50% capacity reduction, ~30 seconds. Fine for swimTO's traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)