### PR TITLE
feat(arc-runners): register bolao-claude with self-hosted ARC

### DIFF
--- a/clusters/eldertree/arc-runners/bolao-claude-dind-daemon-configmap.yaml
+++ b/clusters/eldertree/arc-runners/bolao-claude-dind-daemon-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bolao-claude-dind-daemon
+  namespace: arc-runners
+data:
+  daemon.json: |
+    {
+      "dns": ["10.43.0.10", "8.8.8.8", "1.1.1.1"]
+    }

--- a/clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml
@@ -1,0 +1,101 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bolao-claude-runners
+  namespace: arc-runners
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: "0.14.2"
+      sourceRef:
+        kind: HelmRepository
+        name: arc-charts
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: arc-runners
+  releaseName: bolao-claude-runners
+  install:
+    createNamespace: true
+  upgrade:
+    cleanupOnFail: true
+  dependsOn:
+    - name: arc-controller
+      namespace: arc-controller
+  values:
+    githubConfigUrl: "https://github.com/raolivei/bolao-claude"
+    githubConfigSecret: ollie-runner-github-secret
+
+    minRunners: 0
+    maxRunners: 2
+
+    runnerScaleSetName: "bolao-claude-eldertree"
+
+    scaleSetLabels:
+      - self-hosted
+
+    containerMode:
+      type: "dind"
+
+    template:
+      metadata:
+        labels:
+          workload-type: ci-cd
+      spec:
+        # DinD build containers inherit pod DNS; CoreDNS + 8.8.8.8 fallback
+        # fixes registry.npmjs.org EAI_AGAIN during docker build (bolao-web #243).
+        dnsConfig:
+          nameservers:
+            - 10.43.0.10
+            - 8.8.8.8
+          options:
+            - name: ndots
+              value: "2"
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: actions.github.com/scale-set-name
+                        operator: In
+                        values:
+                          - bolao-claude-eldertree
+                  topologyKey: kubernetes.io/hostname
+        terminationGracePeriodSeconds: 3600
+
+        volumes:
+          - name: dind-daemon-config
+            configMap:
+              name: bolao-claude-dind-daemon
+
+        containers:
+          - name: runner
+            image: ghcr.io/actions/actions-runner:latest
+            command: ["/home/runner/run.sh"]
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1500m
+                memory: 2Gi
+          - name: dind
+            volumeMounts:
+              - name: dind-daemon-config
+                mountPath: /etc/docker/daemon.json
+                subPath: daemon.json
+                readOnly: true
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1536Mi
+
+    controllerServiceAccount:
+      namespace: arc-controller
+      name: arc-controller-gha-rs-controller

--- a/clusters/eldertree/arc-runners/kustomization.yaml
+++ b/clusters/eldertree/arc-runners/kustomization.yaml
@@ -15,4 +15,6 @@ resources:
   - nima-runners-helmrelease.yaml
   - eldertree-docs-runners-helmrelease.yaml
   - bolao-runners-helmrelease.yaml
+  - bolao-claude-runners-helmrelease.yaml
   - bolao-dind-daemon-configmap.yaml
+  - bolao-claude-dind-daemon-configmap.yaml


### PR DESCRIPTION
## Summary

Registers `raolivei/bolao-claude` with the per-repo ARC scale set pattern. Without this, `runs-on: self-hosted` jobs from that repo queue forever (no runner scale set is bound to its `githubConfigUrl`).

## What ships

- `clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml` — clone of `bolao-runners-helmrelease.yaml` with:
  - `githubConfigUrl: https://github.com/raolivei/bolao-claude`
  - `releaseName: bolao-claude-runners`, `runnerScaleSetName: bolao-claude-eldertree`
  - `minRunners: 0`, `maxRunners: 2` (same as bolao)
  - Reuses shared `githubConfigSecret: ollie-runner-github-secret` (PAT covers all raolivei repos)
- `clusters/eldertree/arc-runners/bolao-claude-dind-daemon-configmap.yaml` — per-runner DinD daemon.json with explicit DNS (10.43.0.10 + 8.8.8.8 + 1.1.1.1). Mounted into the dind sidecar at `/etc/docker/daemon.json` to fix `registry.npmjs.org EAI_AGAIN` inside the buildkit container (same fix as bolao).
- Both files added to `clusters/eldertree/arc-runners/kustomization.yaml`.

## Validation

- `kubectl kustomize clusters/eldertree/arc-runners/` → 16 resources render clean (was 14, +2 for the new HelmRelease and ConfigMap).
- Identical structure to `bolao-runners-helmrelease.yaml` and `bolao-dind-daemon-configmap.yaml` so behavior is the same.

## Test plan

- [ ] PR merges → Flux reconciles `clusters/eldertree/arc-runners`
- [ ] HelmRelease ready: `kubectl get helmrelease bolao-claude-runners -n arc-runners`
- [ ] AutoscalingRunnerSet appears: `kubectl get autoscalingrunnerset -n arc-runners | grep bolao-claude`
- [ ] Listener pod Running: `kubectl get pods -n arc-runners -l actions.github.com/scale-set-name=bolao-claude-eldertree`
- [ ] Trigger a build by pushing to `raolivei/bolao-claude` main → ephemeral runner pod spins up within ~30s
- [ ] `git-version-tag` job (currently disabled in bolao-claude workflow) can be re-enabled once this lands

## Follow-up

After merge, in `raolivei/bolao-claude/.github/workflows/build-and-push.yml`:
- Drop `runs-on: ubuntu-latest` (use self-hosted default)
- Drop `platforms: linux/amd64` (Pi runners are arm64 native, no QEMU)
- Re-enable `create-git-tag: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)