### PR TITLE
fix(bolao-claude): ImagePolicy marker placement + cf-cert creationPolicy

### DIFF
--- a/clusters/eldertree/bolao-claude/cloudflare-origin-cert-external.yaml
+++ b/clusters/eldertree/bolao-claude/cloudflare-origin-cert-external.yaml
@@ -1,10 +1,4 @@
 ---
-# ExternalSecret for *.eldertree.xyz Cloudflare Origin Certificate
-# Reuses the wildcard cert stored in Vault (shared across all *.eldertree.xyz subdomains)
-# Used by bolao-claude.eldertree.xyz for public HTTPS access
-#
-# Vault path: secret/swimto/cloudflare-origin-cert-eldertree
-# (Wildcard cert covers *.eldertree.xyz and eldertree.xyz)
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,8 +11,7 @@ spec:
     kind: ClusterSecretStore
   target:
     name: bolao-claude-cloudflare-origin-tls
-    # Merge updates existing secret (e.g. if created manually); avoids "secret already exists" error
-    creationPolicy: Merge
+    creationPolicy: Owner
     template:
       type: kubernetes.io/tls
       data:

--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -22,8 +22,8 @@ spec:
     components:
       bolao-claude-web:
         image:
-          repository: v0.1.0 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
-          tag: v0.1.0
+          repository: ghcr.io/raolivei/bolao-claude-web
+          tag: v0.1.0 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000


### PR DESCRIPTION
## Summary

Two related fixes blocking `bolao-claude` HelmRelease from going Ready after #249 merged.

## (1) ImagePolicy setter on wrong line

`helmrelease.yaml` had the `# {"$imagepolicy": ...}` marker on `repository:` instead of `tag:`. On the first Flux auto-bump (commit 758357d \"chore(bolao-claude): update images v0.1.0\"), it replaced `ghcr.io/raolivei/bolao-claude-web` with `v0.1.0`, producing image ref `v0.1.0:v0.1.0` → containerd resolved as `docker.io/library/v0.1.0` → ImagePullBackOff.

Fix: move marker to the `tag:` line, matching `swimto/helmrelease.yaml` and `bolao/helmrelease.yaml` patterns. Restore `repository: ghcr.io/raolivei/bolao-claude-web`.

## (2) cf-origin cert creationPolicy

`cloudflare-origin-cert-external.yaml` used `creationPolicy: Merge` (cloned from canopy where Merge is intentional because cert-manager already creates a tls Secret in that flow). `bolao-claude` has no pre-creating component, so Merge refuses with:
```
the desired secret bolao-claude-cloudflare-origin-tls was not found.
With creationPolicy=Merge the secret won't be created
```

Fix: `creationPolicy: Owner` so ESO creates the Secret from Vault on first sync.

## After merge

```bash
kubectl get helmrelease -n bolao-claude bolao-claude   # Ready=True
kubectl get pods -n bolao-claude                       # bolao-claude-web Running
kubectl get externalsecret -n bolao-claude             # both SecretSynced=True
curl -fsS https://bolao-claude.eldertree.xyz/api/metrics
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)