### PR TITLE
fix(swimto): bump chart pin to 0.1.3 so deployment-strategy template lands

### DIFF
--- a/clusters/eldertree/swimto/helmrelease.yaml
+++ b/clusters/eldertree/swimto/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/eldertree-app
-      version: "0.1.1"
+      version: "0.1.3"
       sourceRef:
         kind: GitRepository
         name: flux-system

--- a/helm/eldertree-app/Chart.yaml
+++ b/helm/eldertree-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eldertree-app
 description: Shared Helm chart for Eldertree cluster applications
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.0"


### PR DESCRIPTION
## Why

#250 added a ``kindIs "string"`` branch to ``helm/eldertree-app/templates/deployment.yaml`` so ``strategy`` accepts either a legacy string or a full object. The change shipped under chart version ``0.1.2`` (Chart.yaml). But the swimTO HelmRelease still pinned ``version: "0.1.1"`` — last bumped in #149.

When the new helmrelease.yaml values landed (with the object form ``strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 0, maxUnavailable: 1 }}``), Flux fetched the **0.1.1** chart (still string-only template) and rendered the whole object as the type string. Kubernetes rejected the patch:

\`\`\`
spec.strategy: Unsupported value: {"Type":"map[rollingUpdate:map[maxSurge:0 maxUnavailable:1] type:RollingUpdate]","RollingUpdate":null}: supported values: "Recreate", "RollingUpdate"
\`\`\`

HelmRelease went ``Stalled: True``, swimto-api stayed on ``v0.9.1`` while ``v0.9.2`` and ``v0.9.3`` accumulated unconsumed.

## What

Two-line fix:

- ``helm/eldertree-app/Chart.yaml``: ``0.1.2`` → ``0.1.3``. The kindIs change is a real behaviour change and deserves an explicit version bump (rather than relying on Flux re-fetching ``0.1.2`` from a moving target).
- ``clusters/eldertree/swimto/helmrelease.yaml``: pin ``"0.1.1"`` → ``"0.1.3"``.

## Verification

\`helm template\` with the 0.1.3 chart and the new strategy values:

\`\`\`yaml
strategy:
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 1
  type: RollingUpdate
\`\`\`

Correct shape. Kubernetes accepts.

## Test plan

- [ ] Merge.
- [ ] ``flux reconcile kustomization flux-system``; HelmRelease status flips ``Stalled: True`` → ``Ready: True``.
- [ ] ``kubectl -n swimto get pods -l app=swimto-api`` shows pods rolling to ``v0.9.3`` (api image bumped by the auto-promote earlier today).
- [ ] First api pod log line: ``Migration runner starting; dir = /app/migrations`` (the new migrate.py from swimTO#233), then ``Backfilled schema_migrations: ...`` × 4, then uvicorn boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)