### PR TITLE
fix: raise bolao-eldertree ARC maxRunners to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **bolao ARC `maxRunners`** — Raise `bolao-eldertree` from 2 to 4 so PR docker builds do not queue behind main.
+
 - **bolao-web `pullPolicy`** — Set `pullPolicy: Always` on `bolao-web` so Flux semver tag updates re-resolve GHCR digests (canopy pattern; alternative is pinning `image.tag` to digest).
 
 - **bolao-web image** — HelmRelease `bolao-web` tag `v0.1.2` (Google OAuth issuer fix; cluster may run sideload until GHCR publishes).

--- a/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
@@ -28,7 +28,8 @@ spec:
     githubConfigSecret: ollie-runner-github-secret
 
     minRunners: 0
-    maxRunners: 2
+    # PR docker builds queue behind main when maxRunners is too low.
+    maxRunners: 4
 
     runnerScaleSetName: "bolao-eldertree"
 


### PR DESCRIPTION
## Summary
- Increase `bolao-runners` HelmRelease `maxRunners` from 2 to 4 for `bolao-eldertree`
- PR docker builds were queuing behind main with only two concurrent runners

## Test plan
- [ ] Flux reconciles `bolao-runners` in `arc-runners`
- [ ] Multiple bolao workflow jobs can run concurrently (up to 4)


Made with [Cursor](https://cursor.com)