### PR TITLE
fix(bolao-claude): bump eldertree-app chart 0.1.2 → 0.1.3

### DIFF
--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/eldertree-app
-      version: "0.1.2"
+      version: "0.1.3"
       sourceRef:
         kind: GitRepository
         name: flux-system


### PR DESCRIPTION
## Summary

The HelmRelease in `clusters/eldertree/bolao-claude/helmrelease.yaml` pinned chart version `0.1.2` but `helm/eldertree-app/Chart.yaml` is at `0.1.3`. Live HelmRelease wedged on failed `0.1.3` upgrade attempt for ~38h (`context deadline exceeded`) — pods stuck `ImagePullBackOff`.

Aligning the pin with the chart source of truth so Flux can complete the upgrade and pick up the new `ghcr.io/raolivei/bolao-claude-web:v0.1.1` image (CI just published, includes /v4 + /v5 routes for production comparison).

## Test plan

- [ ] Merge → Flux reconciles `clusters/eldertree/bolao-claude`
- [ ] `kubectl get hr -n bolao-claude bolao-claude` → `Ready=True`
- [ ] Pods `bolao-claude-web-*` reach `1/1 Running`
- [ ] `curl https://bolao-claude.eldertree.xyz/v4` and `/v5` → 200
- [ ] Flux ImageUpdateAutomation rewrites `tag: v0.1.0` → `tag: v0.1.1` on `main` within 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)