### PR TITLE
deploy(bolao-claude): claude-v0.1.3

### DIFF
--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -22,8 +22,8 @@ spec:
     components:
       bolao-claude-web:
         image:
-          repository: ghcr.io/raolivei/bolao-claude-web
-          tag: v0.1.2 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
+          repository: ghcr.io/raolivei/bolao-web
+          tag: claude-v0.1.3
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000


### PR DESCRIPTION
GitOps pin for variant restructure deploy (image already rolled out via kubectl).

Made with [Cursor](https://cursor.com)