### PR TITLE
fix(bolao-claude): Cloudflare tunnel DNS for bolao-claude.eldertree.xyz

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -191,6 +191,16 @@ jobs:
         working-directory: .
         run: bash scripts/cloudflare-reconcile-bolao-dns.sh
 
+      - name: Reconcile bolao-claude.eldertree.xyz DNS (tunnel CNAME)
+        if: |
+          steps.plan.outcome == 'success' &&
+          (
+            (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.apply == 'true')
+          )
+        working-directory: .
+        run: bash scripts/cloudflare-reconcile-bolao-claude-dns.sh
+
       - name: Terraform Apply
         id: apply
         if: |

--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -92,4 +92,4 @@ spec:
         tls:
           secretName: bolao-claude-cloudflare-origin-tls
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: bolao-claude.eldertree.xyz
+          external-dns.alpha.kubernetes.io/exclude: "true"

--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -22,8 +22,8 @@ spec:
     components:
       bolao-claude-web:
         image:
-          repository: ghcr.io/raolivei/bolao-claude-web
-          tag: v0.1.2 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
+          repository: ghcr.io/raolivei/bolao-web
+          tag: claude-v0.1.3
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000

--- a/scripts/cloudflare-reconcile-bolao-claude-dns.sh
+++ b/scripts/cloudflare-reconcile-bolao-claude-dns.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Remove stale Cloudflare DNS records for bolao-claude.eldertree.xyz so Terraform can
+# create the tunnel CNAME (cloudflare_record.bolao_claude_eldertree_xyz_tunnel).
+#
+# Usage:
+#   source scripts/lib/load-terraform-secrets-from-vault.sh
+#   export TF_VAR_cloudflare_api_token TF_VAR_cloudflare_zone_id
+#   ./scripts/cloudflare-reconcile-bolao-claude-dns.sh
+
+set -euo pipefail
+
+TOKEN="${TF_VAR_cloudflare_api_token:-${CLOUDFLARE_API_TOKEN:-}}"
+ZONE_ID="${TF_VAR_cloudflare_zone_id:-${CLOUDFLARE_ZONE_ID:-}}"
+NAME="bolao-claude"
+
+if [[ -z "$TOKEN" || -z "$ZONE_ID" ]]; then
+  echo "Need TF_VAR_cloudflare_api_token and TF_VAR_cloudflare_zone_id" >&2
+  exit 1
+fi
+
+api() {
+  curl -sfS -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "$@"
+}
+
+echo "Listing Cloudflare records for ${NAME}.eldertree.xyz (zone ${ZONE_ID})..."
+RECORDS="$(api "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${NAME}.eldertree.xyz")"
+echo "$RECORDS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if not data.get('success'):
+    print('API error:', data, file=sys.stderr)
+    sys.exit(1)
+for r in data.get('result', []):
+    print(f\"{r['id']}\t{r['type']}\t{r.get('content','')}\")
+"
+
+while IFS=$'\t' read -r id rtype content; do
+  [[ -z "$id" ]] && continue
+  if [[ "$rtype" == "CNAME" && "$content" == *".cfargotunnel.com" ]]; then
+    echo "OK: tunnel CNAME already present ($id)"
+    continue
+  fi
+  echo "Deleting ${rtype} record $id (${content})..."
+  api -X DELETE "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${id}" >/dev/null
+  echo "Deleted."
+done < <(echo "$RECORDS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for r in data.get('result', []):
+    print(r['id'], r['type'], r.get('content',''), sep='\t')
+")
+
+echo "Done. Re-run: cd terraform && terraform apply"

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -415,6 +415,13 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "eldertree" {
       service  = "http://10.43.23.214:80"
     }
 
+    # Bolão Claude scratch (design variants)
+    ingress_rule {
+      hostname = "bolao-claude.eldertree.xyz"
+      path     = "/"
+      service  = "http://10.43.23.214:80"
+    }
+
     # Catch-all rule (must be last)
     ingress_rule {
       service = "http_status:404"
@@ -474,6 +481,19 @@ resource "cloudflare_record" "bolao_eldertree_xyz_tunnel" {
   proxied         = true
   allow_overwrite = true
   comment         = "bolao.eldertree.xyz - Bolão dos Guerreiros via Cloudflare Tunnel"
+}
+
+# DNS CNAME record for bolao-claude.eldertree.xyz pointing to tunnel
+resource "cloudflare_record" "bolao_claude_eldertree_xyz_tunnel" {
+  count           = local.cloudflare_enabled && var.cloudflare_account_id != "" && var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id         = data.cloudflare_zone.eldertree_xyz[0].id
+  name            = "bolao-claude"
+  content         = "${cloudflare_zero_trust_tunnel_cloudflared.eldertree[0].id}.cfargotunnel.com"
+  type            = "CNAME"
+  ttl             = 1
+  proxied         = true
+  allow_overwrite = true
+  comment         = "bolao-claude.eldertree.xyz - Bolão Claude scratch via Cloudflare Tunnel"
 }
 
 # DNS CNAME record for blog.eldertree.xyz pointing to GitHub Pages


### PR DESCRIPTION
Public hostname was resolving to Traefik cluster IPs (10.0.0.x) — unreachable from internet. Adds tunnel ingress + CNAME like bolao.eldertree.xyz.

Made with [Cursor](https://cursor.com)