### PR TITLE
fix(bolao-claude): dedicated bolao-claude-web GHCR image

### DIFF
--- a/clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
     - name: arc-controller
       namespace: arc-controller
   values:
-    githubConfigUrl: "https://github.com/raolivei/bolao-claude"
+    githubConfigUrl: "https://github.com/raolivei/bolao"
     githubConfigSecret: ollie-runner-github-secret
 
     minRunners: 0

--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -22,8 +22,8 @@ spec:
     components:
       bolao-claude-web:
         image:
-          repository: ghcr.io/raolivei/bolao-web
-          tag: claude-v0.1.3
+          repository: ghcr.io/raolivei/bolao-claude-web
+          tag: v0.1.3 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
           pullPolicy: IfNotPresent
         replicas: 1
         port: 3000


### PR DESCRIPTION
Restores ghcr.io/raolivei/bolao-claude-web:v0.1.3 in HelmRelease; stops sharing bolao-web:claude-* with production.

Made with [Cursor](https://cursor.com)