### PR TITLE
deploy(bolao): v0.2.1 env + WhatsApp grupo

### DIFF
--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
         # Semver tag from ImagePolicy can point at a new GHCR digest; Always re-pull on pod start.
         image:
           repository: ghcr.io/raolivei/bolao-web
-          tag: v0.2.0 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
+          tag: v0.2.1 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
           pullPolicy: Always
         replicas: 1
         port: 3000
@@ -68,6 +68,12 @@ spec:
                 key: CRON_SECRET
           - name: AUTH_TRUST_HOST
             value: "true"
+          - name: SEED_ADMIN_EMAIL
+            value: "rafa.oliveira1@gmail.com"
+          - name: NEXT_PUBLIC_WHATSAPP_GROUP_URL
+            value: "https://chat.whatsapp.com/ImoLIMLQ7IN7eyXy3VIgin"
+          - name: NEXT_PUBLIC_ADMIN_CONTACT_EMAIL
+            value: "rafa.oliveira1@gmail.com"
         dnsConfig:
           nameservers:
             - 10.43.0.10


### PR DESCRIPTION
## Summary
- Bump `bolao-web` image tag to `v0.2.1`
- `NEXT_PUBLIC_WHATSAPP_GROUP_URL` — Guerreiros de Jah
- `NEXT_PUBLIC_ADMIN_CONTACT_EMAIL` + `SEED_ADMIN_EMAIL` — admin/Interac

Pairs with raolivei/bolao#79 (merged).

## Test plan
- [ ] Flux reconciles HelmRelease
- [ ] `https://bolao.eldertree.xyz/login` shows WhatsApp button
- [ ] Google login promotes admin

Made with [Cursor](https://cursor.com)