### PR TITLE
deploy(bolao-claude): v0.1.7 — redesign Transmissão da Noite

### DIFF
--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -23,8 +23,11 @@ spec:
       bolao-claude-web:
         image:
           repository: ghcr.io/raolivei/bolao-claude-web
-          tag: v0.1.5 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
-          pullPolicy: IfNotPresent
+          tag: v0.1.7 # {"$imagepolicy": "bolao-claude:bolao-claude-web-policy:tag"}
+          # Always: a tag v0.1.7 foi republicada (build 2026-07-03, digest
+          # sha256:56894949…) sobre uma v0.1.7 anterior — Always garante que o
+          # kubelet re-puxe o digest novo em vez de um cache antigo da tag.
+          pullPolicy: Always
         replicas: 1
         port: 3000
         probesEnabled: false


### PR DESCRIPTION
## Summary
- Atualiza a tag da imagem `bolao-claude-web` de `v0.1.5` → `v0.1.7`.
- v0.1.7 = redesign completo "Transmissão da Noite" + unificação com o bolao real (assets reais do Alceu, splash cinematográfica com aurora, bracket sem sobreposição da taça, Alceu interativo em mais páginas, fix de overflow mobile do MatchCard). Imagem construída e publicada no GHCR hoje (digest `sha256:56894949…`).
- `pullPolicy: IfNotPresent → Always`: a tag `v0.1.7` foi republicada sobre uma tag anterior de mesmo nome; `Always` garante que o kubelet puxe o digest novo em vez de um cache antigo.

## Notas
- HelmRelease `bolao-claude` está **suspenso** no cluster (evitava rollback). Após o merge, o deploy será destravado manualmente na ordem segura: reconcile do GitRepository → resume do HelmRelease → reconcile. ImageUpdateAutomation segue suspenso de propósito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)