### PR TITLE
chore(pi-fleet): commit loose untracked files (ollie Ingress + bolao-claude GHCR doc)

### DIFF
--- a/docs/BOLAO_CLAUDE_GHCR.md
+++ b/docs/BOLAO_CLAUDE_GHCR.md
@@ -1,0 +1,48 @@
+# GHCR: bolao-claude-web package access
+
+Production bolao uses `ghcr.io/raolivei/bolao-web`. The scratch deploy must use a **separate** package:
+
+`ghcr.io/raolivei/bolao-claude-web`
+
+## Symptom
+
+CI workflow **Build bolao-claude Web** fails at push:
+
+```text
+403 Forbidden … ghcr.io/v2/raolivei/bolao-claude-web/blobs/…
+```
+
+Build succeeds; only the registry push is denied.
+
+## Cause
+
+The `bolao-claude-web` GHCR package was likely created by (or linked to) a different GitHub repo
+(e.g. a `bolao-claude` repo URL in ARC runner config). `GITHUB_TOKEN` from `raolivei/bolao` cannot
+write until the package grants this repository access.
+
+**Do not** publish scratch images as `bolao-web:claude-*` — that shares the production package.
+
+## Fix (one-time, GitHub UI)
+
+1. Open https://github.com/orgs/raolivei/packages
+2. Find container package **`bolao-claude-web`**
+   - If missing, skip to step 4 (first successful push after permissions will create it)
+3. **Package settings** → **Manage Actions access** → **Add repository** → `raolivei/bolao` → role **Write**
+4. Optional: enable **Inherit access from repository**
+5. Re-run workflow: Actions → **Build bolao-claude Web** → `ref=feat/p2-core-game-loop`
+
+## Verify
+
+```bash
+# After push succeeds
+export KUBECONFIG=~/.kube/config-eldertree
+kubectl set image deployment/bolao-claude-web -n bolao-claude \
+  bolao-claude-web=ghcr.io/raolivei/bolao-claude-web:v0.1.3
+kubectl rollout status deployment/bolao-claude-web -n bolao-claude
+```
+
+Flux ImagePolicy in `bolao-claude` namespace tracks `bolao-claude-web` semver `>=0.1.0 <1.0.0`.
+
+## Build workflow
+
+Defined in `raolivei/bolao`: `.github/workflows/build-bolao-claude.yml` (workflow_dispatch).

--- a/helm/ollie/templates/ingress.yaml
+++ b/helm/ollie/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ollie.fullname" . }}-ingress
+  labels:
+    {{- include "ollie.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ollie.fullname" $ }}-core
+                port:
+                  number: {{ $.Values.core.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## What

Commits two untracked files that were sitting loose in the pi-fleet working tree (found after the `deploy/bolao-claude-v0.1.7` branch was already merged via #267). Base is current `main`; nothing else changes.

### Commits
1. **`feat(helm/ollie): add Ingress template`** — new `helm/ollie/templates/ingress.yaml` for the existing (tracked) `helm/ollie` chart. Part of the **Ollie MCP cutover** (`ollie.eldertree.local`). Guarded by `{{- if .Values.ingress.enabled }}`; `values.yaml` is unchanged, so it is **inert until `ingress.enabled=true`** — no runtime effect on merge.
2. **`docs(bolao-claude): add GHCR package access runbook`** — standalone `docs/BOLAO_CLAUDE_GHCR.md` documenting the `403` on pushing `ghcr.io/raolivei/bolao-claude-web` and the package-permission fix. Accompanies the merged v0.1.7 deploy.

## Notes

- The `helm/ollie` Ingress template belongs to the in-flight **Ollie MCP cutover** — flagging so that effort doesn't duplicate it. It is safe to land now (inert).
- No behavioral change: the Ingress template renders nothing until enabled in values; the doc is documentation only.

## Verify

```bash
helm template helm/ollie --set ingress.enabled=true | grep -A3 "kind: Ingress"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
