### PR TITLE
infra(openclaw): local-first model chain + in-cluster Ollama fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
+- **OpenClaw cluster-local LLM fallback** — [`clusters/eldertree/openclaw/ollama-fallback.yaml`](clusters/eldertree/openclaw/ollama-fallback.yaml): in-cluster `ollama/ollama` Deployment serving `qwen2.5:3b` on a Pi5 (soft-pinned to node-1), `local-path` PVC, and ingress NetworkPolicy. Always-on local fallback for when the Mac Ollama primary is unreachable; pinned image `ollama/ollama:0.31.1`, keeps the model warm between calls (`OLLAMA_KEEP_ALIVE=30m`).
+
 - **bolao Flux image automation** — `ImageRepository`, `ImagePolicy`, and `ImageUpdateAutomation` for `ghcr.io/raolivei/bolao-web`; HelmRelease tag setter comment (swimTO pattern).
 
 ### Changed
+
+- **OpenClaw model chain → local-first** — Primary is now the Mac `ollama/gemma4:31b-mlx` (was `qwen2.5:7b`); fallback chain is cluster `ollama-cluster/qwen2.5:3b` → OpenRouter cloud. Compaction stays on Mac `qwen2.5:7b`. See [`clusters/eldertree/openclaw/configmap.yaml`](clusters/eldertree/openclaw/configmap.yaml).
+
+- **OpenClaw config auto-reload** — Added `configmap.reloader.stakater.com/reload` annotation to the openclaw pod so Stakater Reloader restarts it on `openclaw-config-file` changes (previously the pod kept stale config until a manual restart).
 
 - **bolao ARC `maxRunners`** — Raise `bolao-eldertree` from 2 to 4 so PR docker builds do not queue behind main.
 

--- a/clusters/eldertree/openclaw/README.md
+++ b/clusters/eldertree/openclaw/README.md
@@ -1,6 +1,44 @@
 # OpenClaw Deployment
 
-Personal AI assistant powered by OpenClaw on eldertree with OpenRouter (primary) and Groq fallback, plus Elder for cluster ops, code, and GitHub.
+Personal AI assistant powered by OpenClaw on eldertree. Uses a **local-first** model chain — a large model on the Mac primary, a small cluster-local model as fallback, then free cloud providers — plus Elder for cluster ops, code, and GitHub.
+
+## Model chain (local-first)
+
+Configured in [`configmap.yaml`](configmap.yaml) under `agents.defaults.model`:
+
+| Tier | Model | Runs on | Notes |
+| ---- | ----- | ------- | ----- |
+| **primary** | `ollama/gemma4:31b-mlx` | Mac Ollama (`100.97.229.104:11434` via Tailscale) | 31B, best quality |
+| **fallback 1** | `ollama-cluster/qwen2.5:3b` | Raspberry Pi 5 in-cluster (`ollama-fallback` svc) | 100% local, always-on; CPU-only, ~3-6 tok/s |
+| **fallback 2+** | `openrouter/*` (Gemini Flash, Claude Haiku, Llama 4 Scout) | Cloud (OpenRouter free tier) | last resort, fast |
+| _compaction_ | `ollama/qwen2.5:7b` | Mac Ollama | context summarization only |
+
+The **cluster fallback** is deployed by [`ollama-fallback.yaml`](ollama-fallback.yaml): a pinned
+`ollama/ollama:0.31.1` Deployment (soft-pinned to node-1, the node with most free RAM), a `local-path`
+PVC for the model, and an ingress NetworkPolicy. The model is pulled on first boot and the pod is
+only `Ready` once `qwen2.5:3b` exists. `OLLAMA_KEEP_ALIVE=30m` keeps it warm so a failover isn't a
+CPU cold-start.
+
+> **⚠️ Primary requires the Mac reachable from the cluster.** The primary routes to
+> `100.97.229.104:11434`, a **Tailscale** address — if Tailscale is **stopped** on the Mac, the
+> cluster cannot reach it (`http_code=000`) and every request silently falls through to the fallback
+> tiers. Keep Tailscale **up and persistent** (login item) on the Mac. Alternative: point the `ollama`
+> provider `baseUrl` in [`configmap.yaml`](configmap.yaml) at the Mac's LAN IP (e.g.
+> `http://192.168.2.107:11434/v1`) with a DHCP reservation. Verify the path from inside the cluster:
+> `kubectl -n openclaw exec deploy/openclaw -- curl -s --max-time 8 http://100.97.229.104:11434/api/tags`.
+
+> **Reasoning-model caveat.** `gemma4:31b-mlx` emits a `reasoning` field. Leave its `reasoning`
+> **unset** (= `false`) and do **not** enable `thinkingDefault` for this agent — setting `reasoning:true`
+> on an `openai-completions` Ollama endpoint triggers `reasoning_effort` injection that breaks tool
+> calling ([openclaw#33272](https://github.com/openclaw/openclaw/issues/33272)). If gemma ever returns
+> empty content, raise its `maxTokens` (currently 4096) rather than touching `reasoning`.
+
+> **Context caveat:** Ollama caps context at `OLLAMA_CONTEXT_LENGTH` (set to `16384` on the cluster
+> pod, matching the provider's `contextWindow`). For the Mac primary, set `num_ctx`/`OLLAMA_CONTEXT_LENGTH`
+> on the Mac side if you need the full declared window.
+
+To change the fallback model, edit both `OLLAMA_CONTEXT_LENGTH`/the `ollama pull` line in
+`ollama-fallback.yaml` **and** the `ollama-cluster` provider entry in `configmap.yaml`.
 
 ## ARM64 Build
 
@@ -20,7 +58,7 @@ To rebuild manually:
 ## Features
 
 - **Telegram Integration**: Chat via `@eldertree_assistant_bot`
-- **Multi-Provider LLM**: OpenRouter primary (e.g. Llama, Gemini, Claude) + Groq fallback
+- **Local-first LLM chain**: Mac `gemma4:31b-mlx` primary → cluster `qwen2.5:3b` fallback → OpenRouter/Groq cloud last resort (see [Model chain](#model-chain-local-first))
 - **Elder best-answer**: Elder can query Gemini + Groq in parallel and judge the best answer
 - **SwimTO Integration**: Query Toronto pool schedules
 - **Kubernetes Access**: Cluster-wide operator RBAC via in-pod `kubectl` (workloads, Flux, ingress, secrets, etc.); storage (PV/PVC/snapshots/StorageClass) and cluster control-plane APIs are read-only — see [rbac.yaml](rbac.yaml)
@@ -32,11 +70,11 @@ To rebuild manually:
 ## Architecture
 
 ```
-┌─────────────┐     ┌──────────────┐     ┌─────────────────────────────┐
-│  Telegram   │────▶│   OpenClaw   │────▶│  OpenRouter (primary)       │
-│   Web UI    │◀────│   Gateway    │◀────│  Groq (fallback)            │
-└─────────────┘     └──────┬───────┘     └─────────────────────────────┘
-                           │
+┌─────────────┐     ┌──────────────┐     ┌──────────────────────────────────────┐
+│  Telegram   │────▶│   OpenClaw   │────▶│  1. Mac gemma4:31b-mlx  (Tailscale)  │
+│   Web UI    │◀────│   Gateway    │◀────│  2. Cluster qwen2.5:3b  (Pi5, local) │
+└─────────────┘     └──────┬───────┘     │  3. OpenRouter/Groq     (cloud)      │
+                           │             └──────────────────────────────────────┘
                            ▼
                     ┌──────────────┐     ┌──────────────┐
                     │    Elder     │────▶│  SwimTO API  │
@@ -45,7 +83,9 @@ To rebuild manually:
                     └──────────────┘
 ```
 
-**Resilience:** OpenClaw uses OpenRouter first; if it fails, fallbacks to Groq. Elder can use `elder_best_answer` to query Gemini + Groq in parallel and return the judged best answer.
+**Resilience:** OpenClaw tries the Mac primary first; if unreachable it falls back to the always-on
+cluster-local `qwen2.5:3b`, then to cloud providers. Elder can use `elder_best_answer` to query
+Gemini + Groq in parallel and return the judged best answer.
 
 ## Quick Start
 

--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -68,8 +68,9 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "ollama/qwen2.5:7b",
+            "primary": "ollama/gemma4:31b-mlx",
             "fallbacks": [
+              "ollama-cluster/qwen2.5:3b",
               "openrouter/google/gemini-2.0-flash-001",
               "openrouter/anthropic/claude-3.5-haiku",
               "openrouter/meta-llama/llama-4-scout"
@@ -120,9 +121,28 @@ data:
             "apiKey": "ollama",
             "models": [
               {
+                "id": "gemma4:31b-mlx",
+                "name": "Gemma 4 31B MLX (Local Mac, primary)",
+                "contextWindow": 131072,
+                "maxTokens": 4096
+              },
+              {
                 "id": "qwen2.5:7b",
-                "name": "Qwen 2.5 7B (Local Mac)",
+                "name": "Qwen 2.5 7B (Local Mac, compaction)",
                 "contextWindow": 32768,
+                "maxTokens": 2048
+              }
+            ]
+          },
+          "ollama-cluster": {
+            "api": "openai-completions",
+            "baseUrl": "http://ollama-fallback.openclaw.svc.cluster.local:11434/v1",
+            "apiKey": "ollama",
+            "models": [
+              {
+                "id": "qwen2.5:3b",
+                "name": "Qwen 2.5 3B (Cluster fallback, Pi5 CPU)",
+                "contextWindow": 16384,
                 "maxTokens": 2048
               }
             ]

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -32,6 +32,12 @@ spec:
         port: 18789
         strategy: Recreate
         serviceAccountName: openclaw
+        # Stakater Reloader (running in kube-system) restarts this pod whenever the
+        # openclaw-config-file ConfigMap changes, so model-chain edits take effect
+        # without a manual `kubectl rollout restart`. The init script then re-seeds
+        # openclaw.json from the ConfigMap on the resulting fresh container start.
+        podAnnotations:
+          configmap.reloader.stakater.com/reload: "openclaw-config-file"
         command:
           - /bin/sh
           - -c

--- a/clusters/eldertree/openclaw/kustomization.yaml
+++ b/clusters/eldertree/openclaw/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - configmap.yaml
   - exec-approvals-configmap.yaml
   - skills-configmap.yaml
+  - ollama-fallback.yaml
   # Elder (AI agent sidecar)
   - elder-rbac.yaml
   - elder-externalsecret.yaml

--- a/clusters/eldertree/openclaw/ollama-fallback.yaml
+++ b/clusters/eldertree/openclaw/ollama-fallback.yaml
@@ -1,0 +1,180 @@
+# ============================================================
+# Cluster-local Ollama fallback for OpenClaw
+# ------------------------------------------------------------
+# Serves qwen2.5:3b on a Raspberry Pi 5 (ARM64, CPU-only) so the
+# assistant keeps answering when the Mac Ollama (primary,
+# gemma4:31b-mlx over Tailscale) is unreachable. Cloud providers
+# (OpenRouter/Groq) remain as the last-resort fallbacks.
+#
+# Sized for a Pi5 8GB: model unloads when idle (OLLAMA_KEEP_ALIVE),
+# soft-pinned to node-1 (most free RAM). Model is pulled on first
+# boot and persisted on a local-path PVC so restarts are fast.
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-fallback
+  namespace: openclaw
+  labels:
+    app: openclaw
+    component: ollama-fallback
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate # RWO PVC — only one pod may mount it
+  selector:
+    matchLabels:
+      app: openclaw
+      component: ollama-fallback
+  template:
+    metadata:
+      labels:
+        app: openclaw
+        component: ollama-fallback
+    spec:
+      # Soft-prefer node-1 (most free RAM) for the FIRST schedule. NOTE: the
+      # local-path PVC pins its PV to whichever node binds first, so after that
+      # the pod is effectively hard-pinned to that node on restart (Recreate).
+      # If that node is down/full the fallback tier is unavailable and the cloud
+      # (OpenRouter) tiers below it in configmap.yaml cover the gap.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - node-1.eldertree.local
+      containers:
+        - name: ollama
+          image: ollama/ollama:0.31.1 # pinned; linux/arm64 verified
+          imagePullPolicy: IfNotPresent
+          # Serve, then pull the fallback model in the background so the
+          # server is up immediately; readiness gates on the model existing.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              ollama serve &
+              pid=$!
+              echo "[ollama] waiting for server..."
+              until ollama list >/dev/null 2>&1; do sleep 2; done
+              echo "[ollama] pulling qwen2.5:3b (first boot may take a few minutes)..."
+              ollama pull qwen2.5:3b || echo "[ollama] pull failed; readiness will keep retrying"
+              wait $pid
+          ports:
+            - containerPort: 11434
+          env:
+            - name: OLLAMA_HOST
+              value: "0.0.0.0:11434"
+            - name: OLLAMA_KEEP_ALIVE
+              value: "30m" # keep warm longer so a failover isn't a CPU cold-start
+            - name: OLLAMA_MAX_LOADED_MODELS
+              value: "1"
+            - name: OLLAMA_NUM_PARALLEL
+              value: "1"
+            - name: OLLAMA_CONTEXT_LENGTH
+              value: "16384" # match provider contextWindow in configmap.yaml
+          volumeMounts:
+            - name: ollama-models
+              mountPath: /root/.ollama
+          resources:
+            # Measured working set serving qwen2.5:3b @16k ctx = ~2.71Gi (weights
+            # + KV pre-allocated at load). Request 2Gi so the scheduler accounts
+            # for it (512Mi under-request risks node overcommit); limit 4Gi (~28%
+            # headroom over peak — verified, not OOM-tight).
+            requests: {cpu: "250m", memory: "2Gi"}
+            limits: {cpu: "3500m", memory: "4Gi"}
+          # httpGet liveness — Ollama returns "Ollama is running" on /.
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 11434
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 6
+          # Not Ready until the model is actually pulled — keeps OpenClaw
+          # from routing fallback traffic to an empty server.
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "ollama list | grep -q qwen2.5:3b"
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 30 # `ollama list` can lag while CPU is busy generating
+            failureThreshold: 80 # ~20min budget for the first pull
+      volumes:
+        - name: ollama-models
+          persistentVolumeClaim:
+            claimName: ollama-fallback-models
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-fallback-models
+  namespace: openclaw
+  labels:
+    app: openclaw
+    component: ollama-fallback
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path # explicit; no cluster default StorageClass is set
+  resources:
+    requests:
+      storage: 6Gi # qwen2.5:3b ~2GB + headroom
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-fallback
+  namespace: openclaw
+  labels:
+    app: openclaw
+    component: ollama-fallback
+spec:
+  selector:
+    app: openclaw
+    component: ollama-fallback
+  ports:
+    - protocol: TCP
+      port: 11434
+      targetPort: 11434
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ollama-fallback-ingress
+  namespace: openclaw
+  labels:
+    app: openclaw
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: openclaw
+      component: ollama-fallback
+  ingress:
+    # Allow the OpenClaw gateway pod to reach the model endpoint
+    - from:
+        - podSelector:
+            matchLabels:
+              app: openclaw
+              component: openclaw
+      ports:
+        - protocol: TCP
+          port: 11434
+    # Allow kubelet liveness probes from kube-system
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 11434


### PR DESCRIPTION
## Summary
Switches OpenClaw to a **local-first** model chain and adds an always-on in-cluster fallback.

| Tier | Model | Runs on |
|------|-------|---------|
| primary | `ollama/gemma4:31b-mlx` | Mac Ollama (Tailscale `100.97.229.104`) |
| fallback 1 | `ollama-cluster/qwen2.5:3b` | **new** in-cluster Ollama on Pi5 (node-1) |
| fallback 2+ | `openrouter/*` | cloud, last resort |
| compaction | `ollama/qwen2.5:7b` | Mac |

## Changes
- `configmap.yaml`: primary → gemma4:31b-mlx; prepend cluster fallback; add `ollama-cluster` provider.
- `ollama-fallback.yaml` (new): `ollama/ollama:0.31.1` Deployment (arm64, node-1 soft-affinity, `OLLAMA_CONTEXT_LENGTH=16384`, `KEEP_ALIVE=30m`) + ClusterIP Service + 6Gi local-path PVC + ingress NetworkPolicy. Pulls `qwen2.5:3b` on boot; Ready only once model exists.
- `helmrelease.yaml`: Stakater Reloader annotation so config edits auto-roll openclaw.
- README + CHANGELOG.

## Audited
5-dimension audit (schema/k8s/runtime/network/deploy) + adversarial verification. Blockers cleared: Tailscale brought up (pod→Mac 200/45ms verified); Reloader wired for config reload. Resource request raised to 2Gi (measured working set 2.71Gi). Server-side dry-run + kustomize build clean.

## Post-merge (Flux deploys from main)
1. `flux reconcile kustomization --with-source flux-system`
2. Wait for `ollama-fallback` Ready (qwen2.5:3b pull ~2GB).
3. Reloader rolls openclaw onto new chain (or `kubectl rollout restart deploy/openclaw -n openclaw`).
4. Verify primary/fallback from inside pod + Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)