### PR TITLE
chore: decommission bolao from Eldertree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Removed
+
+- **bolao + bolao-claude** — decommissioned from Eldertree GitOps (`clusters/eldertree/kustomization.yaml`): namespaces, Postgres, cronjobs, ingress, image automation. ARC runners (`bolao-eldertree`, `bolao-claude-eldertree`) removed from `arc-runners`. Postgres exporter and blackbox probe targets dropped.
+
 ### Added
 
 - **OpenClaw cluster-local LLM fallback** — [`clusters/eldertree/openclaw/ollama-fallback.yaml`](clusters/eldertree/openclaw/ollama-fallback.yaml): in-cluster `ollama/ollama` Deployment serving `qwen2.5:3b` on a Pi5 (soft-pinned to node-1), `local-path` PVC, and ingress NetworkPolicy. Always-on local fallback for when the Mac Ollama primary is unreachable; pinned image `ollama/ollama:0.31.1`, keeps the model warm between calls (`OLLAMA_KEEP_ALIVE=30m`).

--- a/clusters/eldertree/arc-runners/kustomization.yaml
+++ b/clusters/eldertree/arc-runners/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - northwaysignal-website-runners-helmrelease.yaml
   - nima-runners-helmrelease.yaml
   - eldertree-docs-runners-helmrelease.yaml
-  - bolao-runners-helmrelease.yaml
-  - bolao-claude-runners-helmrelease.yaml
-  - bolao-dind-daemon-configmap.yaml
-  - bolao-claude-dind-daemon-configmap.yaml
+  # - bolao-runners-helmrelease.yaml # DECOMMISSIONED 2026-07-07
+  # - bolao-claude-runners-helmrelease.yaml
+  # - bolao-dind-daemon-configmap.yaml
+  # - bolao-claude-dind-daemon-configmap.yaml

--- a/clusters/eldertree/kustomization.yaml
+++ b/clusters/eldertree/kustomization.yaml
@@ -20,8 +20,8 @@ resources:
 
   # Applications
   - canopy # Personal finance dashboard
-  - bolao # Bolão dos Guerreiros — WC 2026 prediction pool
-  - bolao-claude # Bolão (Claude scratch) — separate namespace; image ghcr.io/raolivei/bolao-claude-web
+  # - bolao # Bolão — DECOMMISSIONED 2026-07-07 (WC pool no longer needed)
+  # - bolao-claude # Bolão Claude scratch — DECOMMISSIONED 2026-07-07
   - swimto # Toronto pool schedules
   - pitanga/flux-kustomization.yaml # Pitanga Cloud (managed by its own Flux Kustomization)
   - ollie # Workspace assistant with RAG and LLM

--- a/clusters/eldertree/observability/postgres-exporter.yaml
+++ b/clusters/eldertree/observability/postgres-exporter.yaml
@@ -90,4 +90,4 @@ data:
       - swimto-postgres.swimto.svc.cluster.local:5432
       - canopy-postgres.canopy.svc.cluster.local:5432
       - journey-postgres.journey.svc.cluster.local:5432
-      - postgres-service.bolao.svc.cluster.local:5432
+      # - postgres-service.bolao.svc.cluster.local:5432  # DECOMMISSIONED 2026-07-07

--- a/helm/monitoring-stack/values.yaml
+++ b/helm/monitoring-stack/values.yaml
@@ -162,7 +162,7 @@ prometheus:
             - "https://swimto.eldertree.xyz"
             - "https://swimto.app"
             - "https://api.swimto.app/health"
-            - "https://bolao.eldertree.xyz"
+            # - "https://bolao.eldertree.xyz"  # DECOMMISSIONED 2026-07-07
             - "https://pitanga.cloud"
     blackbox-https-ca:
       metrics_path: /probe


### PR DESCRIPTION
## Summary
- Remove `bolao` and `bolao-claude` from Eldertree cluster kustomization (Flux will prune namespaces)
- Remove bolao ARC runners (`bolao-eldertree`, `bolao-claude-eldertree`)
- Drop bolao from postgres-exporter and blackbox monitoring targets

## Test plan
- [ ] Flux reconcile prunes `bolao` and `bolao-claude` namespaces
- [ ] ARC bolao runner HelmReleases removed
- [ ] No bolao pods/cronjobs running

Made with [Cursor](https://cursor.com)