### PR TITLE
fix(openclaw): repoint compaction to existing model (qwen2.5:7b deleted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
-- **OpenClaw model chain → local-first** — Primary is now the Mac `ollama/gemma4:31b-mlx` (was `qwen2.5:7b`); fallback chain is cluster `ollama-cluster/qwen2.5:3b` → OpenRouter cloud. Compaction stays on Mac `qwen2.5:7b`. See [`clusters/eldertree/openclaw/configmap.yaml`](clusters/eldertree/openclaw/configmap.yaml).
+- **OpenClaw model chain → local-first** — Primary is the Mac `ollama/gemma4:31b-mlx`; fallback chain is cluster `ollama-cluster/qwen2.5:3b` → OpenRouter cloud. See [`clusters/eldertree/openclaw/configmap.yaml`](clusters/eldertree/openclaw/configmap.yaml).
+
+- **OpenClaw compaction fix** — Compaction model was `ollama/qwen2.5:7b`, which no longer exists on the Mac (deleted) → every compaction 404'd, causing "auto-compaction could not recover this turn". Repointed to the fast, present `ollama/qwen2.5:3b`; bumped `reserveTokensFloor` 20000→24000 and gemma4 `maxTokens` 4096→8192 for reasoning/tool-call headroom.
 
 - **OpenClaw config auto-reload** — Added `configmap.reloader.stakater.com/reload` annotation to the openclaw pod so Stakater Reloader restarts it on `openclaw-config-file` changes (previously the pod kept stale config until a manual restart).
 

--- a/clusters/eldertree/openclaw/README.md
+++ b/clusters/eldertree/openclaw/README.md
@@ -11,7 +11,7 @@ Configured in [`configmap.yaml`](configmap.yaml) under `agents.defaults.model`:
 | **primary** | `ollama/gemma4:31b-mlx` | Mac Ollama (`100.97.229.104:11434` via Tailscale) | 31B, best quality |
 | **fallback 1** | `ollama-cluster/qwen2.5:3b` | Raspberry Pi 5 in-cluster (`ollama-fallback` svc) | 100% local, always-on; CPU-only, ~3-6 tok/s |
 | **fallback 2+** | `openrouter/*` (Gemini Flash, Claude Haiku, Llama 4 Scout) | Cloud (OpenRouter free tier) | last resort, fast |
-| _compaction_ | `ollama/qwen2.5:7b` | Mac Ollama | context summarization only |
+| _compaction_ | `ollama/qwen2.5:3b` | Mac Ollama | fast context summarization (was `qwen2.5:7b` — deleted from the Mac) |
 
 The **cluster fallback** is deployed by [`ollama-fallback.yaml`](ollama-fallback.yaml): a pinned
 `ollama/ollama:0.31.1` Deployment (soft-pinned to node-1, the node with most free RAM), a `local-path`
@@ -31,7 +31,11 @@ CPU cold-start.
 > **unset** (= `false`) and do **not** enable `thinkingDefault` for this agent — setting `reasoning:true`
 > on an `openai-completions` Ollama endpoint triggers `reasoning_effort` injection that breaks tool
 > calling ([openclaw#33272](https://github.com/openclaw/openclaw/issues/33272)). If gemma ever returns
-> empty content, raise its `maxTokens` (currently 4096) rather than touching `reasoning`.
+> empty content, raise its `maxTokens` (currently 8192) rather than touching `reasoning`.
+>
+> **Latency:** gemma4:31b-mlx runs ~52s to first token and can take 6–10 min for a full
+> openclaw-context reply on this Mac (accepted trade-off for a 31B local brain). Compaction
+> therefore runs on the fast `qwen2.5:3b`, not gemma4.
 
 > **Context caveat:** Ollama caps context at `OLLAMA_CONTEXT_LENGTH` (set to `16384` on the cluster
 > pod, matching the provider's `contextWindow`). For the Mac primary, set `num_ctx`/`OLLAMA_CONTEXT_LENGTH`

--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -79,8 +79,8 @@ data:
           "contextTokens": 80000,
           "compaction": {
             "mode": "safeguard",
-            "reserveTokensFloor": 20000,
-            "model": "ollama/qwen2.5:7b",
+            "reserveTokensFloor": 24000,
+            "model": "ollama/qwen2.5:3b",
             "memoryFlush": {
               "enabled": false
             }
@@ -124,11 +124,11 @@ data:
                 "id": "gemma4:31b-mlx",
                 "name": "Gemma 4 31B MLX (Local Mac, primary)",
                 "contextWindow": 131072,
-                "maxTokens": 4096
+                "maxTokens": 8192
               },
               {
-                "id": "qwen2.5:7b",
-                "name": "Qwen 2.5 7B (Local Mac, compaction)",
+                "id": "qwen2.5:3b",
+                "name": "Qwen 2.5 3B (Local Mac, compaction)",
                 "contextWindow": 32768,
                 "maxTokens": 2048
               }


### PR DESCRIPTION
## Problem
Telegram surfaced repeated **"Auto-compaction could not recover this turn"** errors. Root cause: the compaction model `ollama/qwen2.5:7b` was **deleted from the Mac** (only `gemma4:31b-mlx` + `qwen2.5:3b` remain), so every compaction call 404'd. (This is also why openclaw was failing before — its old primary `qwen2.5:7b` was gone.)

## Fix
- `compaction.model`: `ollama/qwen2.5:7b` → **`ollama/qwen2.5:3b`** (present, TTFT ~0.14s).
- Replace the dead `qwen2.5:7b` entry in the Mac `ollama` provider with `qwen2.5:3b`.
- `reserveTokensFloor` 20000 → 24000; gemma4 `maxTokens` 4096 → 8192 (reasoning + tool-call headroom).
- **Primary stays `gemma4:31b-mlx`** (user accepts ~6–10 min/call for a 31B local brain).

## Verified
- gemma4 replies end-to-end via Telegram (confirmed live).
- config.json valid; kustomize build clean. Reloader will auto-roll openclaw on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)