### PR TITLE
chore: scale bolao workloads to zero on Eldertree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Changed
+
+- **bolao + bolao-claude (scale-down)** — web/postgres `replicas: 0`, cronjobs `suspend: true`, ARC runners `maxRunners: 0` (namespaces retained; PVCs not deleted).
+
 ### Removed
 
 - **bolao + bolao-claude** — decommissioned from Eldertree GitOps (`clusters/eldertree/kustomization.yaml`): namespaces, Postgres, cronjobs, ingress, image automation. ARC runners (`bolao-eldertree`, `bolao-claude-eldertree`) removed from `arc-runners`. Postgres exporter and blackbox probe targets dropped.

--- a/clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-claude-runners-helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
     githubConfigSecret: ollie-runner-github-secret
 
     minRunners: 0
-    maxRunners: 2
+    maxRunners: 0
 
     runnerScaleSetName: "bolao-claude-eldertree"
 

--- a/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/bolao-runners-helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
 
     minRunners: 0
     # PR docker builds queue behind main when maxRunners is too low.
-    maxRunners: 4
+    maxRunners: 0
 
     runnerScaleSetName: "bolao-eldertree"
 

--- a/clusters/eldertree/bolao-claude/cronjob-alceu-feed-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-alceu-feed-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-claude-alceu-feed-sync
   namespace: bolao-claude
 spec:
+  suspend: true
   schedule: "*/20 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao-claude/cronjob-leaderboard-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-leaderboard-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-claude-leaderboard-sync
   namespace: bolao-claude
 spec:
+  suspend: true
   schedule: "*/15 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao-claude/cronjob-results-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-results-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-claude-results-sync
   namespace: bolao-claude
 spec:
+  suspend: true
   schedule: "*/10 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao-claude/cronjob-standings-sync.yaml
+++ b/clusters/eldertree/bolao-claude/cronjob-standings-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-claude-standings-sync
   namespace: bolao-claude
 spec:
+  suspend: true
   schedule: "0 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao-claude/helmrelease.yaml
+++ b/clusters/eldertree/bolao-claude/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           # sha256:56894949…) sobre uma v0.1.7 anterior — Always garante que o
           # kubelet re-puxe o digest novo em vez de um cache antigo da tag.
           pullPolicy: Always
-        replicas: 1
+        replicas: 0
         port: 3000
         probesEnabled: false
         sessionAffinity: ClientIP

--- a/clusters/eldertree/bolao-claude/postgres-deployment.yaml
+++ b/clusters/eldertree/bolao-claude/postgres-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: postgres
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: postgres

--- a/clusters/eldertree/bolao/cronjob-alceu-feed-sync.yaml
+++ b/clusters/eldertree/bolao/cronjob-alceu-feed-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-alceu-feed-sync
   namespace: bolao
 spec:
+  suspend: true
   schedule: "*/20 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao/cronjob-leaderboard-sync.yaml
+++ b/clusters/eldertree/bolao/cronjob-leaderboard-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-leaderboard-sync
   namespace: bolao
 spec:
+  suspend: true
   schedule: "*/15 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao/cronjob-results-sync.yaml
+++ b/clusters/eldertree/bolao/cronjob-results-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-results-sync
   namespace: bolao
 spec:
+  suspend: true
   schedule: "*/5 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao/cronjob-standings-sync.yaml
+++ b/clusters/eldertree/bolao/cronjob-standings-sync.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bolao-standings-sync
   namespace: bolao
 spec:
+  suspend: true
   schedule: "0 * * * *"
   jobTemplate:
     spec:

--- a/clusters/eldertree/bolao/helmrelease.yaml
+++ b/clusters/eldertree/bolao/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           repository: ghcr.io/raolivei/bolao-web
           tag: v0.5.0 # {"$imagepolicy": "bolao:bolao-web-policy:tag"}
           pullPolicy: Always
-        replicas: 1
+        replicas: 0
         port: 3000
         probesEnabled: false
         sessionAffinity: ClientIP

--- a/clusters/eldertree/bolao/postgres-deployment.yaml
+++ b/clusters/eldertree/bolao/postgres-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: postgres
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: postgres


### PR DESCRIPTION
## Summary
- Set web and postgres replicas to 0 for `bolao` and `bolao-claude`
- Suspend all bolao cronjobs
- Disable ARC runner scale sets (`maxRunners: 0`)

## Test plan
- [ ] Merge and confirm Flux does not scale workloads back up
- [ ] `kubectl get pods -n bolao -n bolao-claude` shows no running pods

Made with [Cursor](https://cursor.com)