### PR TITLE
infra(openclaw): qwen2.5:32b LAN-primary + Sonnet-5 escalation wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
-- **OpenClaw model chain → local-first** — Primary is the Mac `ollama/gemma4:31b-mlx`; fallback chain is cluster `ollama-cluster/qwen2.5:3b` → OpenRouter cloud. See [`clusters/eldertree/openclaw/configmap.yaml`](clusters/eldertree/openclaw/configmap.yaml).
+- **OpenClaw model chain → local-first, LAN-primary** — Primary is the Mac `ollama-lan/qwen2.5:32b` reached over LAN (`192.168.2.107`, the Mac is always home on the same network); `ollama-tailscale/qwen2.5:32b` (same model, `100.97.229.104`) is a passive fallback tier for when the Mac leaves the LAN — no manual toggling needed, a dead LAN path fails in ~7ms so failover is instant. Then `ollama-cluster/qwen2.5:3b` → OpenRouter cloud. Replaces the earlier `gemma4:31b-mlx` primary (measured ~52s to first token / 6-10min per reply — too slow; qwen2.5:32b measures ~12s cold load, <1s TTFT). See [`clusters/eldertree/openclaw/configmap.yaml`](clusters/eldertree/openclaw/configmap.yaml).
 
-- **OpenClaw compaction fix** — Compaction model was `ollama/qwen2.5:7b`, which no longer exists on the Mac (deleted) → every compaction 404'd, causing "auto-compaction could not recover this turn". Repointed to the fast, present `ollama/qwen2.5:3b`; bumped `reserveTokensFloor` 20000→24000 and gemma4 `maxTokens` 4096→8192 for reasoning/tool-call headroom.
+- **OpenClaw compaction → cluster** — Compaction model is now `ollama-cluster/qwen2.5:3b` (was `ollama/qwen2.5:7b`, which had been deleted from the Mac → every compaction 404'd, causing "auto-compaction could not recover this turn"). Decoupling compaction from the Mac entirely means it never fails due to the Mac's network path. `reserveTokensFloor` 20000→24000.
+
+- **Elder `elder_best_answer` → opt-in Anthropic/Sonnet-5 escalation** — [raolivei/elder#26](https://github.com/raolivei/elder/pull/26) adds Claude Sonnet 5 (via OpenRouter) as a 4th, opt-in provider for hard multi-hop investigations that local ~30B models don't reliably nail (benchmark evidence: no local MLX model in the 26-35B range matched Sonnet 4.6's root-cause accuracy on a real production debug trace). Default `elder_best_answer` behavior/cost unchanged. Wired `ELDER_OPENROUTER_API_KEY` on the `elder` container in `helmrelease.yaml`, reusing OpenClaw's already-provisioned `openclaw-secrets/OPENROUTER_API_KEY` (no new Vault secret).
 
 - **OpenClaw config auto-reload** — Added `configmap.reloader.stakater.com/reload` annotation to the openclaw pod so Stakater Reloader restarts it on `openclaw-config-file` changes (previously the pod kept stale config until a manual restart).
 

--- a/clusters/eldertree/openclaw/README.md
+++ b/clusters/eldertree/openclaw/README.md
@@ -2,16 +2,28 @@
 
 Personal AI assistant powered by OpenClaw on eldertree. Uses a **local-first** model chain — a large model on the Mac primary, a small cluster-local model as fallback, then free cloud providers — plus Elder for cluster ops, code, and GitHub.
 
-## Model chain (local-first)
+## Model chain (local-first, with on-demand cloud escalation)
 
 Configured in [`configmap.yaml`](configmap.yaml) under `agents.defaults.model`:
 
 | Tier | Model | Runs on | Notes |
 | ---- | ----- | ------- | ----- |
-| **primary** | `ollama/gemma4:31b-mlx` | Mac Ollama (`100.97.229.104:11434` via Tailscale) | 31B, best quality |
-| **fallback 1** | `ollama-cluster/qwen2.5:3b` | Raspberry Pi 5 in-cluster (`ollama-fallback` svc) | 100% local, always-on; CPU-only, ~3-6 tok/s |
-| **fallback 2+** | `openrouter/*` (Gemini Flash, Claude Haiku, Llama 4 Scout) | Cloud (OpenRouter free tier) | last resort, fast |
-| _compaction_ | `ollama/qwen2.5:3b` | Mac Ollama | fast context summarization (was `qwen2.5:7b` — deleted from the Mac) |
+| **primary** | `ollama-lan/qwen2.5:32b` | Mac Ollama, **LAN** (`192.168.2.107:11434`) | Mac is always home on the same LAN as the cluster; fast (~12s cold load, <1s TTFT) |
+| **fallback 1** | `ollama-tailscale/qwen2.5:32b` | Mac Ollama, **Tailscale** (`100.97.229.104:11434`) | same model, in case the Mac ever leaves the LAN. LAN connect-refused fails in ~7ms, so this fires near-instantly — no manual toggling needed. Keep Tailscale running as an always-on login item; it costs nothing when idle. |
+| **fallback 2** | `ollama-cluster/qwen2.5:3b` | Raspberry Pi 5 in-cluster (`ollama-fallback` svc) | 100% local, always-on regardless of the Mac; CPU-only, ~3-6 tok/s |
+| **fallback 3+** | `openrouter/*` (Gemini Flash, Claude Haiku, Llama 4 Scout) | Cloud (OpenRouter free tier) | last resort, fast |
+| _compaction_ | `ollama-cluster/qwen2.5:3b` | Cluster (Pi5) | decoupled from the Mac's network path entirely, so compaction never fails just because the Mac is unreachable |
+
+Why LAN-primary with Tailscale as a passive fallback tier (not primary): OpenClaw's fallback chain is
+**reliability-based** (tries the next entry only when a call fails/errors), not quality-based — so
+ordering LAN first is a pure latency win with no downside, and Tailscale silently covers the "Mac left
+home" case without anyone needing to remember to flip anything.
+
+**For genuinely hard investigations** (deep multi-file/log tracing) that need more reasoning than a
+local ~30B model reliably gives: don't change this passive chain. Instead call Elder's
+`elder_best_answer` with `"anthropic"` in `providers` to explicitly escalate to Claude Sonnet 5 (via
+OpenRouter, reuses this same key) — see [`elder` README](https://github.com/raolivei/elder#readme).
+This keeps the default chat path free/local/private and only pays for cloud when you deliberately ask.
 
 The **cluster fallback** is deployed by [`ollama-fallback.yaml`](ollama-fallback.yaml): a pinned
 `ollama/ollama:0.31.1` Deployment (soft-pinned to node-1, the node with most free RAM), a `local-path`
@@ -19,30 +31,14 @@ PVC for the model, and an ingress NetworkPolicy. The model is pulled on first bo
 only `Ready` once `qwen2.5:3b` exists. `OLLAMA_KEEP_ALIVE=30m` keeps it warm so a failover isn't a
 CPU cold-start.
 
-> **⚠️ Primary requires the Mac reachable from the cluster.** The primary routes to
-> `100.97.229.104:11434`, a **Tailscale** address — if Tailscale is **stopped** on the Mac, the
-> cluster cannot reach it (`http_code=000`) and every request silently falls through to the fallback
-> tiers. Keep Tailscale **up and persistent** (login item) on the Mac. Alternative: point the `ollama`
-> provider `baseUrl` in [`configmap.yaml`](configmap.yaml) at the Mac's LAN IP (e.g.
-> `http://192.168.2.107:11434/v1`) with a DHCP reservation. Verify the path from inside the cluster:
-> `kubectl -n openclaw exec deploy/openclaw -- curl -s --max-time 8 http://100.97.229.104:11434/api/tags`.
-
-> **Reasoning-model caveat.** `gemma4:31b-mlx` emits a `reasoning` field. Leave its `reasoning`
-> **unset** (= `false`) and do **not** enable `thinkingDefault` for this agent — setting `reasoning:true`
-> on an `openai-completions` Ollama endpoint triggers `reasoning_effort` injection that breaks tool
-> calling ([openclaw#33272](https://github.com/openclaw/openclaw/issues/33272)). If gemma ever returns
-> empty content, raise its `maxTokens` (currently 8192) rather than touching `reasoning`.
->
-> **Latency:** gemma4:31b-mlx runs ~52s to first token and can take 6–10 min for a full
-> openclaw-context reply on this Mac (accepted trade-off for a 31B local brain). Compaction
-> therefore runs on the fast `qwen2.5:3b`, not gemma4.
-
 > **Context caveat:** Ollama caps context at `OLLAMA_CONTEXT_LENGTH` (set to `16384` on the cluster
-> pod, matching the provider's `contextWindow`). For the Mac primary, set `num_ctx`/`OLLAMA_CONTEXT_LENGTH`
-> on the Mac side if you need the full declared window.
+> pod, matching the provider's `contextWindow`). For the Mac providers, set `num_ctx`/`OLLAMA_CONTEXT_LENGTH`
+> on the Mac side if you need a window other than qwen2.5:32b's default.
 
-To change the fallback model, edit both `OLLAMA_CONTEXT_LENGTH`/the `ollama pull` line in
-`ollama-fallback.yaml` **and** the `ollama-cluster` provider entry in `configmap.yaml`.
+To change the primary/fallback Mac model, edit both `ollama-lan` and `ollama-tailscale` provider
+entries in `configmap.yaml` (keep them in sync — same model, different `baseUrl`). To change the
+cluster fallback model, edit both the `ollama pull` line in `ollama-fallback.yaml` **and** the
+`ollama-cluster` provider entry in `configmap.yaml`.
 
 ## ARM64 Build
 
@@ -62,8 +58,8 @@ To rebuild manually:
 ## Features
 
 - **Telegram Integration**: Chat via `@eldertree_assistant_bot`
-- **Local-first LLM chain**: Mac `gemma4:31b-mlx` primary → cluster `qwen2.5:3b` fallback → OpenRouter/Groq cloud last resort (see [Model chain](#model-chain-local-first))
-- **Elder best-answer**: Elder can query Gemini + Groq in parallel and judge the best answer
+- **Local-first LLM chain**: Mac `qwen2.5:32b` primary (LAN, Tailscale fallback) → cluster `qwen2.5:3b` → OpenRouter/Groq cloud last resort (see [Model chain](#model-chain-local-first-with-on-demand-cloud-escalation))
+- **Elder best-answer**: Elder can query Gemini + Groq + Ollama in parallel and judge the best answer; pass `"anthropic"` to opt in to Claude Sonnet 5 for harder investigations
 - **SwimTO Integration**: Query Toronto pool schedules
 - **Kubernetes Access**: Cluster-wide operator RBAC via in-pod `kubectl` (workloads, Flux, ingress, secrets, etc.); storage (PV/PVC/snapshots/StorageClass) and cluster control-plane APIs are read-only — see [rbac.yaml](rbac.yaml)
 - **Elder Agent**: Code browsing, GitHub issues/PRs, FluxCD, project planning
@@ -74,12 +70,12 @@ To rebuild manually:
 ## Architecture
 
 ```
-┌─────────────┐     ┌──────────────┐     ┌──────────────────────────────────────┐
-│  Telegram   │────▶│   OpenClaw   │────▶│  1. Mac gemma4:31b-mlx  (Tailscale)  │
-│   Web UI    │◀────│   Gateway    │◀────│  2. Cluster qwen2.5:3b  (Pi5, local) │
-└─────────────┘     └──────┬───────┘     │  3. OpenRouter/Groq     (cloud)      │
-                           │             └──────────────────────────────────────┘
-                           ▼
+┌─────────────┐     ┌──────────────┐     ┌───────────────────────────────────────┐
+│  Telegram   │────▶│   OpenClaw   │────▶│  1. Mac qwen2.5:32b  (LAN)           │
+│   Web UI    │◀────│   Gateway    │◀────│  2. Mac qwen2.5:32b  (Tailscale)     │
+└─────────────┘     └──────┬───────┘     │  3. Cluster qwen2.5:3b  (Pi5, local) │
+                           │             │  4. OpenRouter/Groq     (cloud)       │
+                           ▼             └───────────────────────────────────────┘
                     ┌──────────────┐     ┌──────────────┐
                     │    Elder     │────▶│  SwimTO API  │
                     │  (cluster,   │     │  (internal)  │
@@ -87,9 +83,11 @@ To rebuild manually:
                     └──────────────┘
 ```
 
-**Resilience:** OpenClaw tries the Mac primary first; if unreachable it falls back to the always-on
-cluster-local `qwen2.5:3b`, then to cloud providers. Elder can use `elder_best_answer` to query
-Gemini + Groq in parallel and return the judged best answer.
+**Resilience:** OpenClaw tries the Mac over LAN first (fastest); a dead LAN path fails in ~7ms so it
+falls through to the same Mac model over Tailscale near-instantly, then to the always-on cluster-local
+`qwen2.5:3b`, then to cloud providers. Elder's `elder_best_answer` queries Gemini + Groq + Ollama in
+parallel and judges the best answer for its normal tool calls; pass `"anthropic"` in `providers` to
+explicitly escalate a hard investigation to Claude Sonnet 5 (see [Model chain](#model-chain-local-first-with-on-demand-cloud-escalation)).
 
 ## Quick Start
 

--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -68,8 +68,9 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "ollama/gemma4:31b-mlx",
+            "primary": "ollama-lan/qwen2.5:32b",
             "fallbacks": [
+              "ollama-tailscale/qwen2.5:32b",
               "ollama-cluster/qwen2.5:3b",
               "openrouter/google/gemini-2.0-flash-001",
               "openrouter/anthropic/claude-3.5-haiku",
@@ -80,7 +81,7 @@ data:
           "compaction": {
             "mode": "safeguard",
             "reserveTokensFloor": 24000,
-            "model": "ollama/qwen2.5:3b",
+            "model": "ollama-cluster/qwen2.5:3b",
             "memoryFlush": {
               "enabled": false
             }
@@ -115,22 +116,29 @@ data:
               }
             ]
           },
-          "ollama": {
+          "ollama-lan": {
+            "api": "openai-completions",
+            "baseUrl": "http://192.168.2.107:11434/v1",
+            "apiKey": "ollama",
+            "models": [
+              {
+                "id": "qwen2.5:32b",
+                "name": "Qwen 2.5 32B (Local Mac, primary, LAN)",
+                "contextWindow": 32768,
+                "maxTokens": 8192
+              }
+            ]
+          },
+          "ollama-tailscale": {
             "api": "openai-completions",
             "baseUrl": "http://100.97.229.104:11434/v1",
             "apiKey": "ollama",
             "models": [
               {
-                "id": "gemma4:31b-mlx",
-                "name": "Gemma 4 31B MLX (Local Mac, primary)",
-                "contextWindow": 131072,
-                "maxTokens": 8192
-              },
-              {
-                "id": "qwen2.5:3b",
-                "name": "Qwen 2.5 3B (Local Mac, compaction)",
+                "id": "qwen2.5:32b",
+                "name": "Qwen 2.5 32B (Local Mac, fallback when off-LAN)",
                 "contextWindow": 32768,
-                "maxTokens": 2048
+                "maxTokens": 8192
               }
             ]
           },

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -193,6 +193,15 @@ spec:
                 name: elder-secrets
                 key: GROQ_API_KEY
                 optional: true
+          - name: ELDER_OPENROUTER_API_KEY
+            valueFrom:
+              secretKeyRef:
+                # Reuses OpenClaw's already-provisioned OpenRouter key (same ns) —
+                # no new Vault secret needed. Powers the opt-in Anthropic/Sonnet-5
+                # provider in elder_best_answer.
+                name: openclaw-secrets
+                key: OPENROUTER_API_KEY
+                optional: true
           - name: ELDER_GMAIL_CLIENT_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Why
- `gemma4:31b-mlx` measured ~52s to first token / 6-10min per real reply — too slow. `qwen2.5:32b` measures ~12s cold load, <1s TTFT.
- Mac is always home on the same LAN as the cluster (confirmed), so Tailscale doesn't need to be the primary path — it's a better fit as a passive fallback tier.
- Companion to [raolivei/elder#26](https://github.com/raolivei/elder/pull/26): wires the secret that powers the new opt-in Anthropic/Sonnet-5 provider.

## What
- `configmap.yaml`: `ollama` provider split into `ollama-lan` (`192.168.2.107`, primary) + `ollama-tailscale` (`100.97.229.104`, fallback tier) — both serving `qwen2.5:32b`. `primary = ollama-lan/qwen2.5:32b`, fallbacks prepend `ollama-tailscale/qwen2.5:32b`. `compaction.model = ollama-cluster/qwen2.5:3b` (was tied to the Mac; now always-on regardless of Mac network state).
- `helmrelease.yaml`: `ELDER_OPENROUTER_API_KEY` env on the `elder` container, sourced from the existing `openclaw-secrets/OPENROUTER_API_KEY` (same namespace, no new secret).
- README rewritten for the new chain (LAN→Tailscale→cluster→cloud) + Elder escalation pointer; CHANGELOG updated.

## Verified
- Pod→Mac LAN reachable (200/53ms), pod→closed-port fail-fast (~7ms — confirms near-instant LAN→Tailscale failover).
- `qwen2.5:32b` benchmarked on the Mac: 12s cold load, 0.47s TTFT (small prompt), 44s TTFT (~25k-token prompt).
- All model chain refs resolve to declared providers; `kustomize build` + server-side dry-run clean; `helm template` confirms the new env var renders correctly.

## Deploy runbook
1. Merge → Flux reconciles.
2. `kubectl rollout restart deploy/openclaw -n openclaw` (or wait for Reloader) — picks up the new model chain.
3. Merge [elder#26](https://github.com/raolivei/elder/pull/26) and wait for the new image tag to promote (ImageUpdateAutomation) before `ELDER_OPENROUTER_API_KEY` has any effect.
4. Verify: `kubectl -n openclaw exec deploy/openclaw -- curl -s --max-time 8 http://192.168.2.107:11434/api/tags` (primary), then a Telegram message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)