### PR TITLE
infra(arc-runners): raise elder dind resource limits

### DIFF
--- a/clusters/eldertree/arc-runners/elder-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/elder-runners-helmrelease.yaml
@@ -72,12 +72,16 @@ spec:
                 memory: 2Gi
           - name: dind
             resources:
+              # Requests stay minimal (bursty usage); limit raised — 1000m/1536Mi
+              # was too tight for the frontend's npm ci+tsc+vite build (esbuild's
+              # postinstall spawns a subprocess; under CPU/memory pressure this
+              # class of npm bug manifests as "Exit handler never called!").
               requests:
                 cpu: 50m
                 memory: 256Mi
               limits:
-                cpu: 1000m
-                memory: 1536Mi
+                cpu: 2000m
+                memory: 3Gi
 
     controllerServiceAccount:
       namespace: arc-controller


### PR DESCRIPTION
## Why
raolivei/elder#26's CI build hung 141s then crashed with npm's own \"Exit handler never called!\" bug during \`npm ci\` (esbuild's postinstall spawns a subprocess to download+verify a native binary). The \`dind\` container's limit (1000m CPU / 1536Mi memory) is tight for a Node build (npm ci + tsc + vite) sharing a Pi5.

## What
Raise \`dind\` container **limits only** (1000m→2000m CPU, 1536Mi→3Gi memory). Requests stay at 50m/256Mi — no change to scheduling density, this only gives legitimate bursts more headroom.

## Companion fix
raolivei/elder#26 also switches the frontend-builder base image \`node:20-alpine\` → \`node:20-slim\` (glibc), addressing the same underlying esbuild-postinstall bug class independently. Both changes target the same failure from different angles (resource headroom + avoiding the musl-specific trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)