### PR TITLE
infra(elder): fix Ollama base URL (was localhost, unreachable) + drop OpenRouter wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Added
 
+- **Elder Ollama wiring (was pointing nowhere)** — `elder-configmap.yaml` had no `ELDER_OLLAMA_BASE_URL`, so `elder_best_answer`'s `ollama`/`ollama-heavy` providers defaulted to `localhost:11434` (unreachable from inside the pod) with model `qwen2.5:14b` (never pulled on the Mac) — reported `available: true` (a bare truthy check) but never actually worked. Now points at the Mac's LAN IP (`192.168.2.107`, same as OpenClaw's primary) with models that are actually present (`qwen2.5:32b` fast, `qwen3.6:35b-mlx` heavy — see [raolivei/elder#27](https://github.com/raolivei/elder/pull/27)). Also removes the now-unused `ELDER_OPENROUTER_API_KEY` wiring (elder#27 replaced the Anthropic/OpenRouter escalation provider with a local one).
+
 - **OpenClaw cluster-local LLM fallback** — [`clusters/eldertree/openclaw/ollama-fallback.yaml`](clusters/eldertree/openclaw/ollama-fallback.yaml): in-cluster `ollama/ollama` Deployment serving `qwen2.5:3b` on a Pi5 (soft-pinned to node-1), `local-path` PVC, and ingress NetworkPolicy. Always-on local fallback for when the Mac Ollama primary is unreachable; pinned image `ollama/ollama:0.31.1`, keeps the model warm between calls (`OLLAMA_KEEP_ALIVE=30m`).
 
 - **bolao Flux image automation** — `ImageRepository`, `ImagePolicy`, and `ImageUpdateAutomation` for `ghcr.io/raolivei/bolao-web`; HelmRelease tag setter comment (swimTO pattern).

--- a/clusters/eldertree/openclaw/elder-configmap.yaml
+++ b/clusters/eldertree/openclaw/elder-configmap.yaml
@@ -10,3 +10,11 @@ data:
   ELDER_REPO_SYNC_INTERVAL_HOURS: "6"
   ELDER_GITHUB_OWNER: "raolivei"
   ELDER_LLM_TIMEOUT_SECONDS: "30"
+  # Was defaulting to localhost:11434 (unreachable from inside the pod) with
+  # model qwen2.5:14b (not even pulled on the Mac) -- elder_best_answer's
+  # "ollama"/"ollama-heavy" providers were reporting available=true (a bare
+  # truthy check) but never actually worked. Point at the same Mac LAN IP
+  # OpenClaw's primary uses, and models that are actually present.
+  ELDER_OLLAMA_BASE_URL: "http://192.168.2.107:11434"
+  ELDER_OLLAMA_MODEL: "qwen2.5:32b"
+  ELDER_OLLAMA_HEAVY_MODEL: "qwen3.6:35b-mlx"

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -193,15 +193,6 @@ spec:
                 name: elder-secrets
                 key: GROQ_API_KEY
                 optional: true
-          - name: ELDER_OPENROUTER_API_KEY
-            valueFrom:
-              secretKeyRef:
-                # Reuses OpenClaw's already-provisioned OpenRouter key (same ns) —
-                # no new Vault secret needed. Powers the opt-in Anthropic/Sonnet-5
-                # provider in elder_best_answer.
-                name: openclaw-secrets
-                key: OPENROUTER_API_KEY
-                optional: true
           - name: ELDER_GMAIL_CLIENT_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Why
Companion to [raolivei/elder#27](https://github.com/raolivei/elder/pull/27) (replaces the Anthropic/OpenRouter escalation provider with a local \`ollama-heavy\`). Discovered while wiring it up: \`elder-config\` never set \`ELDER_OLLAMA_BASE_URL\`, so elder's Ollama providers defaulted to \`localhost:11434\` — unreachable from inside the pod — with model \`qwen2.5:14b\`, which was never even pulled on the Mac. \`available: true\` was a bare truthy check on the URL string, not a real reachability probe, so this silently never worked.

## What
- \`ELDER_OLLAMA_BASE_URL\`: \`http://192.168.2.107:11434\` (Mac LAN, same as OpenClaw's primary)
- \`ELDER_OLLAMA_MODEL\`: \`qwen2.5:32b\` (fast, already present — matches OpenClaw's primary)
- \`ELDER_OLLAMA_HEAVY_MODEL\`: \`qwen3.6:35b-mlx\` (heavy, already pulled — powers elder#27's \`ollama-heavy\` provider)
- Removed \`ELDER_OPENROUTER_API_KEY\` wiring (unused now)

## Verified
- \`kubectl kustomize\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)