### PR TITLE
fix(openclaw-arm64): patch upstream CLI help-render timeout for QEMU builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Fixed
+
+- **`build-openclaw-arm64.yml` timing out** — the workflow builds on `ubuntu-latest` under QEMU emulation (no arm64 CI runner for pi-fleet yet). Upstream OpenClaw's `scripts/write-cli-startup-metadata.ts` hardcodes a 120s timeout for rendering CLI help text (spawns a subprocess per command); under emulation a single build phase (`tsdown`) has taken 25+ minutes, so 120s reliably timed out (`Failed to render source browser help: timed out after 120000ms`). No env override exists upstream, so `clusters/eldertree/openclaw/docker/Dockerfile` now `sed`-patches both render timeout constants to 600s right after `git clone`, with a `grep` verification so the patch fails loudly (not silently) if upstream renames the constants.
+
 ### Changed
 
 - **bolao + bolao-claude (scale-down)** — web/postgres `replicas: 0`, cronjobs `suspend: true`, ARC runners `maxRunners: 0` (namespaces retained; PVCs not deleted).

--- a/clusters/eldertree/openclaw/docker/Dockerfile
+++ b/clusters/eldertree/openclaw/docker/Dockerfile
@@ -24,6 +24,20 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
+# `pnpm build` renders CLI help text by spawning a subprocess per command; this
+# repo builds under QEMU emulation (no arm64 CI runner yet -- see workflow
+# comment), which is ~10-20x slower than native. Upstream hardcodes a 120s
+# timeout for these renders (scripts/write-cli-startup-metadata.ts) with no
+# env override; under emulation a single build phase here has taken 25+
+# minutes, so 120s reliably times out. Raise to 10 minutes -- generous, but
+# still bounded so a genuine hang doesn't run forever.
+RUN sed -i \
+    -e 's/^const ROOT_HELP_RENDER_TIMEOUT_MS = 120_000;/const ROOT_HELP_RENDER_TIMEOUT_MS = 600_000;/' \
+    -e 's/^const BROWSER_HELP_RENDER_TIMEOUT_MS = 120_000;/const BROWSER_HELP_RENDER_TIMEOUT_MS = 600_000;/' \
+    scripts/write-cli-startup-metadata.ts && \
+    grep -q 'ROOT_HELP_RENDER_TIMEOUT_MS = 600_000' scripts/write-cli-startup-metadata.ts && \
+    grep -q 'BROWSER_HELP_RENDER_TIMEOUT_MS = 600_000' scripts/write-cli-startup-metadata.ts
+
 RUN pnpm install --frozen-lockfile
 
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build


### PR DESCRIPTION
## Why
Both of the last 2 scheduled runs of `build-openclaw-arm64.yml` failed after 32-42min:

```
Error: Failed to render source browser help: timed out after 120000ms
```

The workflow builds on `ubuntu-latest` under QEMU emulation (see the workflow's own comment: "pi-fleet has no Eldertree scale set yet"). Upstream OpenClaw's `scripts/write-cli-startup-metadata.ts` hardcodes a 120s timeout for two render-CLI-help operations, with no env override. Under QEMU, a single build phase (`tsdown`) in the *same* run legitimately took 1502s (25min) and still succeeded — 120s is simply an unrealistic budget for this environment.

## What
Since the Dockerfile does a fresh `git clone` of upstream OpenClaw every build, `sed`-patch both timeout constants (`ROOT_HELP_RENDER_TIMEOUT_MS`, `BROWSER_HELP_RENDER_TIMEOUT_MS`) from 120s → 600s right after clone, before `pnpm install`/`pnpm build`. A `grep` verification after the `sed` makes the build fail loudly (not silently) if upstream ever renames these constants.

## Considered but not done
The durable fix is a native arm64 ARC runner for pi-fleet (matching the pattern already used for elder/canopy/swimTO/etc.), eliminating QEMU entirely. That's new cluster infra (a HelmRelease + runner registration) — flagging as a follow-up, not bundling it into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)