### PR TITLE
feat(arc-runners): register pitanga-website with self-hosted ARC

### DIFF
--- a/clusters/eldertree/arc-runners/kustomization.yaml
+++ b/clusters/eldertree/arc-runners/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - swimto-runners-helmrelease.yaml
   - personal-website-runners-helmrelease.yaml
   - northwaysignal-website-runners-helmrelease.yaml
+  - pitanga-website-runners-helmrelease.yaml
   - nima-runners-helmrelease.yaml
   - eldertree-docs-runners-helmrelease.yaml
   # - bolao-runners-helmrelease.yaml # DECOMMISSIONED 2026-07-07

--- a/clusters/eldertree/arc-runners/pitanga-website-runners-helmrelease.yaml
+++ b/clusters/eldertree/arc-runners/pitanga-website-runners-helmrelease.yaml
@@ -1,0 +1,84 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pitanga-website-runners
+  namespace: arc-runners
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: "0.14.2"
+      sourceRef:
+        kind: HelmRepository
+        name: arc-charts
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: arc-runners
+  releaseName: pitanga-website-runners
+  install:
+    createNamespace: true
+  upgrade:
+    cleanupOnFail: true
+  dependsOn:
+    - name: arc-controller
+      namespace: arc-controller
+  values:
+    githubConfigUrl: "https://github.com/raolivei/pitanga-website"
+    githubConfigSecret: ollie-runner-github-secret
+
+    minRunners: 0
+    maxRunners: 1
+
+    runnerScaleSetName: "pitanga-website-eldertree"
+
+    scaleSetLabels:
+      - self-hosted
+
+    containerMode:
+      type: "dind"
+
+    template:
+      metadata:
+        labels:
+          workload-type: ci-cd
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: actions.github.com/scale-set-name
+                        operator: In
+                        values:
+                          - pitanga-website-eldertree
+                  topologyKey: kubernetes.io/hostname
+        terminationGracePeriodSeconds: 3600
+
+        containers:
+          - name: runner
+            image: ghcr.io/actions/actions-runner:latest
+            command: ["/home/runner/run.sh"]
+            resources:
+              # Minimal requests — scheduler uses requests; real DinD usage is bursty.
+              # node-1 (unstable) used when node-2/3 stable nodes are full.
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1500m
+                memory: 2Gi
+          - name: dind
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1536Mi
+
+    controllerServiceAccount:
+      namespace: arc-controller
+      name: arc-controller-gha-rs-controller


### PR DESCRIPTION
## Summary
- `pitanga-website` was the only active site on eldertree without its own GitHub Actions runner scale set, so its `build-and-push.yml` workflow (which requires `runs-on: self-hosted`) queues forever — see [run 28995192691](https://github.com/raolivei/pitanga-website/actions/runs/28995192691), which timed out after 24h waiting for a runner.
- Adds `pitanga-website-runners-helmrelease.yaml`, mirroring `northwaysignal-website-runners-helmrelease.yaml` exactly (`minRunners: 0`, `maxRunners: 1`, `dind` container mode, shared `ollie-runner-github-secret`).
- Registers it in `clusters/eldertree/arc-runners/kustomization.yaml`.

## Test plan
- [x] `kubectl kustomize clusters/eldertree/arc-runners/` builds cleanly with the new HelmRelease included
- [ ] After merge, confirm FluxCD reconciles `pitanga-website-runners` HelmRelease in `arc-runners` namespace (`kubectl get helmrelease -n arc-runners`)
- [ ] Re-run the queued pitanga-website build (or push a new commit) and confirm a runner picks up the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)