### PR TITLE
feat(openclaw): switch primary model to qwen3.6:35b-mlx (Mac GPU, MLX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **OpenClaw primary model → qwen3.6:35b-mlx (Mac GPU)** — switched from `qwen2.5:32b` to `qwen3.6:35b-mlx` (MLX-optimized Apple Silicon build, 21GB, already on Mac) as primary and compaction model. Fallback chain: `ollama-lan/qwen3.6:35b-mlx` → `ollama-tailscale/qwen3.6:35b-mlx` → `ollama-lan/qwen2.5:32b` → `ollama-cluster/qwen2.5:3b` → openrouter/\*.
+
 - **bolao + bolao-claude (scale-down)** — web/postgres `replicas: 0`, cronjobs `suspend: true`, ARC runners `maxRunners: 0` (namespaces retained; PVCs not deleted).
 
 ### Removed

--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -68,9 +68,10 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "ollama-lan/qwen2.5:32b",
+            "primary": "ollama-lan/qwen3.6:35b-mlx",
             "fallbacks": [
-              "ollama-tailscale/qwen2.5:32b",
+              "ollama-tailscale/qwen3.6:35b-mlx",
+              "ollama-lan/qwen2.5:32b",
               "ollama-cluster/qwen2.5:3b",
               "openrouter/google/gemini-2.0-flash-001",
               "openrouter/anthropic/claude-3.5-haiku",
@@ -82,7 +83,7 @@ data:
             "mode": "safeguard",
             "reserveTokens": 8500,
             "reserveTokensFloor": 8500,
-            "model": "ollama-lan/qwen2.5:32b",
+            "model": "ollama-lan/qwen3.6:35b-mlx",
             "memoryFlush": {
               "enabled": false
             }
@@ -123,8 +124,14 @@ data:
             "apiKey": "ollama",
             "models": [
               {
+                "id": "qwen3.6:35b-mlx",
+                "name": "Qwen 3.6 35B MLX (Local Mac, primary, LAN)",
+                "contextWindow": 32768,
+                "maxTokens": 8192
+              },
+              {
                 "id": "qwen2.5:32b",
-                "name": "Qwen 2.5 32B (Local Mac, primary, LAN)",
+                "name": "Qwen 2.5 32B (Local Mac, secondary, LAN)",
                 "contextWindow": 32768,
                 "maxTokens": 8192
               }
@@ -135,6 +142,12 @@ data:
             "baseUrl": "http://100.97.229.104:11434/v1",
             "apiKey": "ollama",
             "models": [
+              {
+                "id": "qwen3.6:35b-mlx",
+                "name": "Qwen 3.6 35B MLX (Local Mac, primary, Tailscale)",
+                "contextWindow": 32768,
+                "maxTokens": 8192
+              },
               {
                 "id": "qwen2.5:32b",
                 "name": "Qwen 2.5 32B (Local Mac, fallback when off-LAN)",


### PR DESCRIPTION
## Summary

- Switch OpenClaw primary from `qwen2.5:32b` → `qwen3.6:35b-mlx` (MLX-optimized Apple Silicon build, already on Mac)
- Same model for compaction (runs on Mac GPU via LAN)
- Add `qwen3.6:35b-mlx` to both `ollama-lan` and `ollama-tailscale` provider model lists
- Fallback chain: `ollama-lan/qwen3.6:35b-mlx` → `ollama-tailscale/qwen3.6:35b-mlx` → `ollama-lan/qwen2.5:32b` → `ollama-cluster/qwen2.5:3b` → openrouter/*
- `qwen2.5:32b` kept as mid-chain fallback (already pulled, free to keep)

## Test plan

- [ ] Merge + wait for Flux to reconcile (~2min)
- [ ] Stakater Reloader auto-restarts OpenClaw pod on ConfigMap change
- [ ] Send a Telegram message to @eldertree_assistant_bot, verify response comes from `qwen3.6:35b-mlx`
- [ ] Confirm no "Auto-compaction could not recover" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)