### PR TITLE
fix(openclaw): raise qwen3.6 context window to 65536, contextTokens to 60k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ### Changed
 
+- **OpenClaw qwen3.6:35b-mlx context window raised to 65536** — `contextWindow` 32768→65536 (both ollama-lan and ollama-tailscale entries), `contextTokens` 30000→60000. Root cause: tool-heavy tasks (e.g. `kubectl logs`) return large outputs that pushed conversations past 31830 tokens — leaving only 938 tokens of headroom and making compaction impossible (needs the full prompt to fit in context). With 65536: usable budget = 60000 − 8500 = 51500 tokens. Requires `OLLAMA_NUM_CTX=65536` on Mac Ollama (see below).
+
 - **OpenClaw primary model → qwen3.6:35b-mlx (Mac GPU)** — switched from `qwen2.5:32b` to `qwen3.6:35b-mlx` (MLX-optimized Apple Silicon build, 21GB, already on Mac) as primary and compaction model. Fallback chain: `ollama-lan/qwen3.6:35b-mlx` → `ollama-tailscale/qwen3.6:35b-mlx` → `ollama-lan/qwen2.5:32b` → `ollama-cluster/qwen2.5:3b` → openrouter/\*.
 
 - **bolao + bolao-claude (scale-down)** — web/postgres `replicas: 0`, cronjobs `suspend: true`, ARC runners `maxRunners: 0` (namespaces retained; PVCs not deleted).

--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -78,7 +78,7 @@ data:
               "openrouter/meta-llama/llama-4-scout"
             ]
           },
-          "contextTokens": 30000,
+          "contextTokens": 60000,
           "compaction": {
             "mode": "safeguard",
             "reserveTokens": 8500,
@@ -126,7 +126,7 @@ data:
               {
                 "id": "qwen3.6:35b-mlx",
                 "name": "Qwen 3.6 35B MLX (Local Mac, primary, LAN)",
-                "contextWindow": 32768,
+                "contextWindow": 65536,
                 "maxTokens": 8192
               },
               {
@@ -145,7 +145,7 @@ data:
               {
                 "id": "qwen3.6:35b-mlx",
                 "name": "Qwen 3.6 35B MLX (Local Mac, primary, Tailscale)",
-                "contextWindow": 32768,
+                "contextWindow": 65536,
                 "maxTokens": 8192
               },
               {


### PR DESCRIPTION
## Problem

Tool-heavy tasks (`kubectl logs`, cluster audit) return large outputs that pushed conversations to **31,830 tokens** — leaving only 938 tokens of headroom under the 32768 hard limit. Compaction can't run when it can't fit the full prompt in context:

```
preflightEstimatedTokens=31830  contextWindow=32768  compactionAttempts=0
error=Context overflow: prompt too large for the model (precheck).
```

## Fix

- `contextWindow` 32768 → **65536** for `qwen3.6:35b-mlx` (both `ollama-lan` and `ollama-tailscale`)
- `contextTokens` 30000 → **60000**
- Usable budget: 60000 − 8500 (reserveTokens) = **51500 tokens**

Qwen3 supports up to 128k context. Mac has 51GB unified memory; qwen3.6:35b-mlx is 21GB, leaving ~30GB for a 65536 KV cache (~17GB at fp16).

## Required Mac action (one-time, before merging)

```bash
launchctl setenv OLLAMA_NUM_CTX 65536
pkill -x ollama
open /Applications/Ollama.app
```

This sets the default Ollama context length. Ollama caps each model at its own max, so qwen2.5:32b (32768 max) is unaffected.

## Test plan

- [ ] Run Mac action above, confirm Ollama restarts cleanly
- [ ] Merge + Flux reconcile (~2min), Reloader restarts OpenClaw pod
- [ ] Send a Telegram message that triggers tool use (e.g. `check cluster logs`)
- [ ] Confirm no `Context overflow: prompt too large` error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)