### PR TITLE
feat(openclaw): Flux image automation — auto-deploy on weekly ARM64 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Dates are ISO 86
 
 ## [Unreleased]
 
+### Added
+
+- **OpenClaw image automation** — Flux now tracks `ghcr.io/raolivei/openclaw` and auto-deploys new builds without manual intervention. `build-openclaw-arm64.yml` already pushes `YYYYMMDD` date tags on every build; new `ImageRepository` + `ImagePolicy` (numerical ascending, filter `^[0-9]{8}$`) scan for the latest date tag hourly. The existing `elder-image-update.yaml` (path `./clusters/eldertree/openclaw`, strategy `Setters`) picks up the new `$imagepolicy` marker on the HelmRelease `openclaw.image.tag` field automatically. When a new weekly build lands, Flux commits the updated tag to `main` and redeploys within ~3 minutes (now that Flux intervals are fixed in PR #285).
+
 ### Fixed
 
 - **Flux not auto-reconciling on merge** — `clusters/eldertree/flux-system/gotk-sync.yaml` (which sets the GitRepository and Kustomization intervals) was never included in `clusters/eldertree/kustomization.yaml`, so the file existed in git but was **never applied** by Flux. The live cluster was running the original bootstrap values: GitRepository `interval: 1m`, Kustomization `interval: 10m` (and wrong `branch: flux-bootstrap`). Changes to intervals or branch in `gotk-sync.yaml` had zero effect; any PR merged required a manual `annotate --overwrite` force-reconcile to land within <10 minutes. Fix: added `- flux-system` to `clusters/eldertree/kustomization.yaml` (listed first so Flux updates its own schedule before applying apps), set GitRepository `interval: 1m`, Kustomization `interval: 2m`, branch `main`. After this merges + one final force-reconcile, all future PRs will land within ~3 minutes automatically.

--- a/clusters/eldertree/openclaw/helmrelease.yaml
+++ b/clusters/eldertree/openclaw/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
       openclaw:
         image:
           repository: ghcr.io/raolivei/openclaw
-          tag: latest
+          tag: latest # {"$imagepolicy": "openclaw:openclaw:tag"}
           pullPolicy: Always
         port: 18789
         strategy: Recreate

--- a/clusters/eldertree/openclaw/kustomization.yaml
+++ b/clusters/eldertree/openclaw/kustomization.yaml
@@ -20,5 +20,7 @@ resources:
   - helmrelease.yaml
   - elder-image-repo.yaml
   - elder-image-policy.yaml
+  - openclaw-image-repo.yaml
+  - openclaw-image-policy.yaml
   - elder-image-update.yaml
   - control-cloudflare-origin-cert-external.yaml

--- a/clusters/eldertree/openclaw/openclaw-image-policy.yaml
+++ b/clusters/eldertree/openclaw/openclaw-image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  imageRepositoryRef:
+    name: openclaw
+  # build-openclaw-arm64.yml pushes YYYYMMDD tags on every build.
+  # Numerical ascending picks the most recent date.
+  filterTags:
+    pattern: "^[0-9]{8}$"
+  policy:
+    numerical:
+      order: asc

--- a/clusters/eldertree/openclaw/openclaw-image-repo.yaml
+++ b/clusters/eldertree/openclaw/openclaw-image-repo.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  # OpenClaw ARM64 image (built weekly via build-openclaw-arm64.yml)
+  image: ghcr.io/raolivei/openclaw
+  interval: 1h
+  secretRef:
+    name: ghcr-secret


### PR DESCRIPTION
## What this does

Closes the self-update loop for OpenClaw. Previously OpenClaw used `tag: latest` with `pullPolicy: Always` — it got the new image on pod restart, but Flux had no visibility into when `latest` actually changed and couldn't auto-deploy.

## How it works

`build-openclaw-arm64.yml` already pushes three tags per build: `latest`, `YYYYMMDD` (e.g. `20260713`), and short SHA. The date tag is the stable handle Flux tracks.

**New resources:**
- `openclaw-image-repo.yaml` — `ImageRepository` scanning `ghcr.io/raolivei/openclaw` hourly
- `openclaw-image-policy.yaml` — `ImagePolicy` selecting the latest `YYYYMMDD` tag (numerical ascending, filter `^[0-9]{8}$`)
- `helmrelease.yaml` — `tag: latest # {"$imagepolicy": "openclaw:openclaw:tag"}` marker added

**No new `ImageUpdateAutomation` needed** — the existing `elder-image-update.yaml` already covers `path: ./clusters/eldertree/openclaw` with `strategy: Setters`, so it automatically picks up the new marker.

## Full loop after this merges

```
Sunday 06:00 UTC — build-openclaw-arm64.yml pushes 20260720
  → ImageRepository detects within 1h
  → ImagePolicy resolves to 20260720
  → ImageUpdateAutomation commits:
      tag: 20260720 # {"$imagepolicy": "openclaw:openclaw:tag"}
  → Flux GitRepository picks up commit within 1m (PR #285)
  → Kustomization reconciles within 2m (PR #285)
  → Helm upgrade → new OpenClaw pod
```

Zero manual steps. Same pattern as Elder (which already self-deploys via semver).

## First run behaviour

On first reconcile after merge, `latest` ≠ `20260713` (the most recent date tag), so Flux will commit an update immediately and roll a new OpenClaw pod tagged `20260713`. The image content is identical to `latest` — only the tag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)