### PR TITLE
fix(helm/ollie): add default ingress block to values.yaml

### DIFF
--- a/helm/ollie/values.yaml
+++ b/helm/ollie/values.yaml
@@ -5,6 +5,14 @@ global:
 audio:
   enabled: false
 
+# Ingress (ollie.eldertree.local) — inert until enabled=true
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
 # Mac Ollama via Tailscale (override per environment)
 ollama:
   externalUrl: "http://host.docker.internal:11434"


### PR DESCRIPTION
## Summary
- The Flux `HelmRelease` for `ollie/ollie` has been failing every reconcile with: `template: ollie/templates/ingress.yaml:1:14: executing "ollie/templates/ingress.yaml" at <.Values.ingress.enabled>: nil pointer evaluating interface {}.enabled`
- `templates/ingress.yaml` (added in #268) reads `.Values.ingress.enabled`, but no `ingress` key was ever added to `helm/ollie/values.yaml`, and the HelmRelease's `values:` block doesn't set one either — so `.Values.ingress` is `nil`, not an empty map, and Helm panics.
- Adds a default `ingress` block (`enabled: false`) to `values.yaml`, matching the "inert until enabled=true" intent from #268.

## Test plan
- [x] `helm template ollie ./helm/ollie` renders successfully with no error, Ingress resource correctly omitted
- [ ] Flux reconciles `ollie/ollie` HelmRelease successfully after merge