### PR TITLE
fix(helm/ollie): bump chart version to 0.1.1 to force repackage

### DIFF
--- a/clusters/eldertree/ollie/helmrelease.yaml
+++ b/clusters/eldertree/ollie/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ./helm/ollie
-      version: "0.1.0"
+      version: "0.1.1"
       sourceRef:
         kind: GitRepository
         name: flux-system

--- a/helm/ollie/Chart.yaml
+++ b/helm/ollie/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: ollie
 description: A Helm chart for Ollie Local AI
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 


### PR DESCRIPTION
## Summary
- #288 fixed the ingress nil-pointer bug in `values.yaml`, but the HelmRelease's `ollie-ollie` HelmChart uses `reconcileStrategy: ChartVersion` — source-controller only repackages the chart artifact when `Chart.yaml`'s `version` changes.
- Since #288 didn't bump the version, the packaged artifact stayed stale (still the pre-fix content), so the release kept failing with the same nil-pointer error even after merge.
- Bumps `helm/ollie/Chart.yaml` to `0.1.1` and the HelmRelease's pinned `chart.spec.version` to match.

## Test plan
- [ ] Flux repackages the chart artifact at the new version
- [ ] `ollie/ollie` HelmRelease reconciles to `Ready: True`