### PR TITLE
feat(swimto-dev): dev environment on eldertree cluster

### DIFF
--- a/clusters/eldertree/kustomization.yaml
+++ b/clusters/eldertree/kustomization.yaml
@@ -25,7 +25,8 @@ resources:
   - canopy # Personal finance dashboard
   # - bolao # Bolão — DECOMMISSIONED 2026-07-07 (WC pool no longer needed)
   # - bolao-claude # Bolão Claude scratch — DECOMMISSIONED 2026-07-07
-  - swimto # Toronto pool schedules
+  - swimto # Toronto pool schedules (prod — semver tags, swimto.app)
+  - swimto-dev # SwimTO dev environment (build-timestamp tags, swimto-dev.eldertree.local)
   - pitanga/flux-kustomization.yaml # Pitanga Cloud (managed by its own Flux Kustomization)
   - ollie # Workspace assistant with RAG and LLM
   # - nima          # AI/ML learning project (DISABLED - not needed)

--- a/clusters/eldertree/swimto-dev/cronjob-refresh.yaml
+++ b/clusters/eldertree/swimto-dev/cronjob-refresh.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: swimto-dev-data-refresh
+  namespace: swimto-dev
+spec:
+  # 4 AM daily — one hour after prod (3 AM) to avoid simultaneous Open Data hammering
+  schedule: "0 4 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: data-refresh
+              image: ghcr.io/raolivei/swimto-api:latest # {"$imagepolicy": "swimto-dev:swimto-api-dev-policy"}
+              imagePullPolicy: Always
+              command:
+                - python
+                - /data-pipeline/jobs/daily_refresh.py
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: swimto-dev-secrets
+                      key: DATABASE_URL
+              envFrom:
+                - configMapRef:
+                    name: swimto-dev-config
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+          imagePullSecrets:
+            - name: ghcr-secret
+          restartPolicy: OnFailure

--- a/clusters/eldertree/swimto-dev/ghcr-secret-external.yaml
+++ b/clusters/eldertree/swimto-dev/ghcr-secret-external.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-secret
+  namespace: swimto-dev
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      engineVersion: v2
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "raolivei",
+                "password": "{{ .token }}",
+                "auth": "{{ printf `raolivei:%s` .token | b64enc }}"
+              }
+            }
+          }
+  data:
+    - secretKey: token
+      remoteRef:
+        key: secret/canopy/ghcr-token
+        property: token

--- a/clusters/eldertree/swimto-dev/helmrelease.yaml
+++ b/clusters/eldertree/swimto-dev/helmrelease.yaml
@@ -1,0 +1,147 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: swimto-dev
+  namespace: swimto-dev
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: ./helm/eldertree-app
+      version: "0.1.3"
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: swimto-dev
+  releaseName: swimto-dev
+  upgrade:
+    cleanupOnFail: true
+  values:
+    # ============================================================
+    # SwimTO Dev — mirrors prod with 1 replica, local ingress only
+    # Tracks build-<timestamp>-<sha> tags (auto-deploys every main push)
+    # ============================================================
+    components:
+      swimto-api:
+        replicas: 1
+        strategy: RollingUpdate
+        image:
+          repository: ghcr.io/raolivei/swimto-api
+          tag: latest # {"$imagepolicy": "swimto-dev:swimto-api-dev-policy:tag"}
+          pullPolicy: Always
+        port: 8000
+        env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: swimto-dev-secrets
+                key: DATABASE_URL
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: swimto-dev-secrets
+                key: REDIS_URL
+          - name: ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: swimto-dev-secrets
+                key: ADMIN_TOKEN
+          - name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: swimto-dev-secrets
+                key: SECRET_KEY
+        envFrom:
+          - configMapRef:
+              name: swimto-dev-config
+        resources:
+          requests: {cpu: "100m", memory: "128Mi"}
+          limits: {cpu: "300m", memory: "384Mi"}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]
+        probes:
+          path: /health
+          liveness: {initialDelaySeconds: 30, periodSeconds: 10}
+          readiness: {initialDelaySeconds: 10, periodSeconds: 5}
+      swimto-web:
+        replicas: 1
+        strategy: RollingUpdate
+        image:
+          repository: ghcr.io/raolivei/swimto-web
+          tag: latest # {"$imagepolicy": "swimto-dev:swimto-web-dev-policy:tag"}
+          pullPolicy: Always
+        port: 3000
+        probesEnabled: false
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests: {cpu: "50m", memory: "64Mi"}
+          limits: {cpu: "100m", memory: "128Mi"}
+        volumeMounts:
+          - name: nginx-cache
+            mountPath: /var/cache/nginx
+          - name: nginx-run
+            mountPath: /var/run
+          - name: nginx-tmp
+            mountPath: /tmp
+        volumes:
+          - name: nginx-cache
+            emptyDir: {}
+          - name: nginx-run
+            emptyDir: {}
+          - name: nginx-tmp
+            emptyDir: {}
+    # -- ConfigMaps
+    configMaps:
+      swimto-dev-config:
+        data:
+          CITY_BASE_URL: "https://www.toronto.ca"
+          OPEN_DATA_BASE_URL: "https://open.toronto.ca"
+          INGEST_WINDOW_DAYS: "56"
+          LOG_LEVEL: "DEBUG"
+          GOOGLE_REDIRECT_URI: "https://swimto-dev.eldertree.local/auth/callback"
+          CORS_ORIGINS: '["http://localhost:5173","http://localhost:3000","https://swimto-dev.eldertree.local","http://swimto-dev.eldertree.local"]'
+    # -- Middleware
+    middleware:
+      api-path-rewrite:
+        type: replacePathRegex
+        regex: "^/api(/.*?)/?$"
+        replacement: "$1"
+      redirect-https:
+        type: redirectScheme
+        scheme: https
+        permanent: true
+    # -- Ingress (local only — no external exposure for dev)
+    ingress:
+      swimto-dev-api:
+        host: swimto-dev.eldertree.local
+        service: swimto-api
+        path: /api
+        port: 8000
+        middlewares:
+          - swimto-dev-redirect-https@kubernetescrd
+          - swimto-dev-api-path-rewrite@kubernetescrd
+        tls:
+          secretName: swimto-dev-tls
+          certManager: true
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: swimto-dev.eldertree.local
+      swimto-dev-web:
+        host: swimto-dev.eldertree.local
+        service: swimto-web
+        port: 3000
+        middlewares:
+          - swimto-dev-redirect-https@kubernetescrd
+        tls:
+          secretName: swimto-dev-tls
+          certManager: true
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: swimto-dev.eldertree.local

--- a/clusters/eldertree/swimto-dev/image-policies.yaml
+++ b/clusters/eldertree/swimto-dev/image-policies.yaml
@@ -1,0 +1,33 @@
+# Dev tracks build-<timestamp>-<sha> tags produced on every push to main.
+# These are emitted by docker-build.yml when is_default_branch=true.
+# Alphabetical/asc on the timestamp prefix picks the newest build.
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: swimto-api-dev-policy
+  namespace: swimto-dev
+spec:
+  imageRepositoryRef:
+    name: swimto-api-dev
+  filterTags:
+    pattern: '^build-(?P<ts>\d{14})-'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: swimto-web-dev-policy
+  namespace: swimto-dev
+spec:
+  imageRepositoryRef:
+    name: swimto-web-dev
+  filterTags:
+    pattern: '^build-(?P<ts>\d{14})-'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc

--- a/clusters/eldertree/swimto-dev/image-repositories.yaml
+++ b/clusters/eldertree/swimto-dev/image-repositories.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: swimto-api-dev
+  namespace: swimto-dev
+spec:
+  image: ghcr.io/raolivei/swimto-api
+  interval: 5m
+  secretRef:
+    name: ghcr-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: swimto-web-dev
+  namespace: swimto-dev
+spec:
+  image: ghcr.io/raolivei/swimto-web
+  interval: 5m
+  secretRef:
+    name: ghcr-secret

--- a/clusters/eldertree/swimto-dev/image-update-automation.yaml
+++ b/clusters/eldertree/swimto-dev/image-update-automation.yaml
@@ -1,0 +1,25 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: swimto-dev-updates
+  namespace: swimto-dev
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: "chore(swimto-dev): update images{{range .Changed.Changes}} {{.NewValue}}{{end}}"
+    push:
+      branch: main
+  update:
+    path: ./clusters/eldertree/swimto-dev
+    strategy: Setters

--- a/clusters/eldertree/swimto-dev/kustomization.yaml
+++ b/clusters/eldertree/swimto-dev/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  # Secrets (must exist before HelmRelease)
+  - ghcr-secret-external.yaml
+  - swimto-dev-secrets-external.yaml
+  # Infrastructure (stateful, kept outside Helm)
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - redis-deployment.yaml
+  # Helm-managed app (api, web, configmap, ingress, middleware)
+  - helmrelease.yaml
+  # CronJobs
+  - cronjob-refresh.yaml
+  # Image automation (Flux requirement: stays separate)
+  - image-repositories.yaml
+  - image-policies.yaml
+  - image-update-automation.yaml

--- a/clusters/eldertree/swimto-dev/namespace.yaml
+++ b/clusters/eldertree/swimto-dev/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: swimto-dev
+  labels:
+    name: swimto-dev
+    app: swimto
+    environment: dev

--- a/clusters/eldertree/swimto-dev/postgres-deployment.yaml
+++ b/clusters/eldertree/swimto-dev/postgres-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: swimto-dev
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: pools
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: swimto-dev-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  namespace: swimto-dev
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/clusters/eldertree/swimto-dev/postgres-pvc.yaml
+++ b/clusters/eldertree/swimto-dev/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: swimto-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/clusters/eldertree/swimto-dev/redis-deployment.yaml
+++ b/clusters/eldertree/swimto-dev/redis-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: swimto-dev
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+  namespace: swimto-dev
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis
+  type: ClusterIP

--- a/clusters/eldertree/swimto-dev/swimto-dev-secrets-external.yaml
+++ b/clusters/eldertree/swimto-dev/swimto-dev-secrets-external.yaml
@@ -1,0 +1,41 @@
+# Vault setup (one-time, before first deploy):
+#   vault kv put secret/swimto-dev/app \
+#     POSTGRES_PASSWORD="<dev-password>" \
+#     DATABASE_URL="postgresql+psycopg://postgres:<dev-password>@postgres-service.swimto-dev.svc.cluster.local:5432/pools" \
+#     REDIS_URL="redis://redis-service.swimto-dev.svc.cluster.local:6379/0" \
+#     ADMIN_TOKEN="<dev-token>" \
+#     SECRET_KEY="<dev-secret-key>"
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: swimto-dev-secrets
+  namespace: swimto-dev
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: swimto-dev-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: secret/swimto-dev/app
+        property: POSTGRES_PASSWORD
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: secret/swimto-dev/app
+        property: DATABASE_URL
+    - secretKey: REDIS_URL
+      remoteRef:
+        key: secret/swimto-dev/app
+        property: REDIS_URL
+    - secretKey: ADMIN_TOKEN
+      remoteRef:
+        key: secret/swimto-dev/app
+        property: ADMIN_TOKEN
+    - secretKey: SECRET_KEY
+      remoteRef:
+        key: secret/swimto-dev/app
+        property: SECRET_KEY


### PR DESCRIPTION
## Summary

Adds a `swimto-dev` namespace — a full isolated dev environment for swimTO that auto-deploys on every push to `main`. Migrations always run here first before they reach prod.

- **URL**: `swimto-dev.eldertree.local` (local only, no external exposure)
- Own Postgres (5Gi PVC) + own Redis — completely isolated from prod DB
- Own secrets from Vault `secret/swimto-dev/app`
- 1 replica, no anti-affinity, lower resource limits
- Flux `ImagePolicy` tracks `build-<timestamp>-<sha>` tags → auto-deploys ~5 min after any push to `main`
- Daily refresh CronJob at 4 AM (prod at 3 AM)

## Dev → prod gate

```
push to main  →  build-<ts>-<sha> tag  →  swimto-dev auto-deploys  →  validate
                                                                          ↓
                                           bump VERSION  →  v* tag  →  prod deploys
```

## Prerequisites before merging

**1. Vault secrets** (one-time):
```bash
vault kv put secret/swimto-dev/app \
  POSTGRES_PASSWORD="<dev-password>" \
  DATABASE_URL="postgresql+psycopg://postgres:<dev-password>@postgres-service.swimto-dev.svc.cluster.local:5432/pools" \
  REDIS_URL="redis://redis-service.swimto-dev.svc.cluster.local:6379/0" \
  ADMIN_TOKEN="<dev-token>" \
  SECRET_KEY="<dev-secret-key>"
```

**2. github-workflows PR #27** must merge first so Flux has `build-*` tags to track.

## Test plan
- [ ] Vault secrets written
- [ ] github-workflows #27 merged
- [ ] This PR merged → `kubectl get pods -n swimto-dev` all Running
- [ ] `https://swimto-dev.eldertree.local` and `/api/health` respond
- [ ] Push trivial swimTO commit → dev updates within 10 min; prod unchanged
- [ ] Bump VERSION in swimTO → prod updates; dev already has it

🤖 Generated with [Claude Code](https://claude.com/claude-code)