### PR TITLE
fix(openclaw): raise compaction reserveTokens to 20000

### DIFF
--- a/clusters/eldertree/openclaw/configmap.yaml
+++ b/clusters/eldertree/openclaw/configmap.yaml
@@ -91,8 +91,8 @@ data:
           "contextTokens": 60000,
           "compaction": {
             "mode": "safeguard",
-            "reserveTokens": 8500,
-            "reserveTokensFloor": 8500,
+            "reserveTokens": 20000,
+            "reserveTokensFloor": 20000,
             "model": "ollama-lan/qwen3.6:35b-mlx",
             "memoryFlush": {
               "enabled": false


### PR DESCRIPTION
## Problem

`reserveTokens` and `reserveTokensFloor` were both `8500`, tuned when `contextTokens` was `30000`. `contextTokens` was later raised to `60000` (to handle large `kubectl logs` outputs) but the compaction reserve was never updated. Result: "Auto-compaction could not recover this turn" at scale.

## Fix

`reserveTokens`: 8500 → 20000  
`reserveTokensFloor`: 8500 → 20000

Usable compaction budget: `60000 - 20000 = 40000 tokens` (still plenty for real conversations; was 51500 before).

Follows the suggestion in the OpenClaw error message itself.

## Test plan

- [ ] Merge → Stakater Reloader restarts OpenClaw pod automatically
- [ ] Start a long conversation and verify compaction completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)